### PR TITLE
Bono/refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,15 @@ import { IonApp } from '@ionic/vue'
 if you added an `App.vue` file, add the following to your global css file:
 
 ```css
-body { 
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: auto;
-  transform: none;
+html {
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+}
+body {
+  transform: none !important;
+  height: unset !important;
+  max-height: unset !important;
+  position: relative !important;
 }
 ```
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
   }
 }
 

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -13,13 +13,14 @@ $toolsBreakPoint: 472px;
 }
 html {
   background-color: var(--red);
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
 }
 body {
-  background-color: var(--darkblue) !important;
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: auto;
   transform: none;
+  height: unset !important;
+  max-height: unset !important;
+  position: relative !important;
 }
 
 .ion-page {

--- a/components/StreamSwitcher.vue
+++ b/components/StreamSwitcher.vue
@@ -55,7 +55,6 @@ watch(allCurrentStations, (val) => {
 
 let initialNoPlayToggleFlag = false
 const onDropdownChange = async (event) => {
-  console.log('event happening = ', event)
   await updateLiveStream(event.value.slug)
   // update slug
   currentStreamStation.value =
@@ -133,7 +132,7 @@ const onDropdownChange = async (event) => {
       content: '';
       position: absolute;
       width: 0;
-      bottom: -30px;
+      bottom: -29px;
       height: 15px;
       left: 30px;
       z-index: 10;

--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -88,7 +88,7 @@ const visibleLeft = ref(false)
 
 <style lang="scss">
 header {
-  background-color: rgba(var(--red), 0.9);
+  background-color: transparentize(#de1e3d, 0.1);
   backdrop-filter: blur(5px);
   position: fixed;
   top: 0;

--- a/composables/data/liveStream.ts
+++ b/composables/data/liveStream.ts
@@ -7,7 +7,7 @@ export async function updateLiveStream(slug: string) {
     currentEpisodeHolder.value = fetchData.data.value
 }
 
-export async function updateAllLiveStreams() {
+export async function updateAllLiveStreams(refresh: boolean = false) {
     const config = useRuntimeConfig()
     const allCurrentStations = useAllCurrentStations()
     const currentStreamStation = useCurrentStreamStation()
@@ -25,9 +25,11 @@ export async function updateAllLiveStreams() {
     allCurrentStations.value = fetchingAll.filter(Boolean)
 
     // set initial stream with the `currentStreamStation` value in the states.ts file
+    //if (refresh) {
     const initialStation = allCurrentStations.value.find(
         (station) =>
             station.data.data[0].attributes.slug === currentStreamStation.value
     ).data
     currentEpisodeHolder.value = initialStation
+    //}
 }

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,11 +11,11 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
-  pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
-  pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
-  pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
-  pod 'CapacitorPushNotifications', :path => '../../node_modules/@capacitor/push-notifications'
-  pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapacitorApp', :path => '..\..\node_modules\@capacitor\app'
+  pod 'CapacitorHaptics', :path => '..\..\node_modules\@capacitor\haptics'
+  pod 'CapacitorKeyboard', :path => '..\..\node_modules\@capacitor\keyboard'
+  pod 'CapacitorPushNotifications', :path => '..\..\node_modules\@capacitor\push-notifications'
+  pod 'CapacitorStatusBar', :path => '..\..\node_modules\@capacitor\status-bar'
 end
 
 target 'WNYC' do

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,7 @@ import { App, URLOpenListenerEvent } from '@capacitor/app'
 import { PushNotifications } from '@capacitor/push-notifications'
 import { useNavigation } from '~/composables/states'
 import { updateAllLiveStreams } from '~/composables/data/liveStream'
-
+const { isMobile, isDesktop } = useDevice()
 const route = useRoute()
 const router = useRouter()
 const config = useRuntimeConfig()
@@ -106,11 +106,27 @@ onBeforeMount(() => {
   //initially load all the streams
   updateAllLiveStreams()
   //refresh data every time the tab is in focus
-  // document.addEventListener('visibilitychange', () => {
-  //   if (!document.hidden) {
-  //     updateAllLiveStreams()
-  //   }
-  // })
+  document.addEventListener('visibilitychange', (event) => {
+    if (!document.hidden) {
+      //console.log('focused tab =', event)
+      updateAllLiveStreams()
+      isRefreshing.value = true
+      setTimeout(() => {
+        isRefreshing.value = false
+      }, 1500)
+    }
+  })
+  //refresh data every time the cursor enters the window on desktop only
+  if (isDesktop) {
+    document.addEventListener('pointerenter', () => {
+      //console.log('pointerenter = ', event)
+      updateAllLiveStreams()
+      isRefreshing.value = true
+      setTimeout(() => {
+        isRefreshing.value = false
+      }, 1500)
+    })
+  }
 
   if (isApp.value) {
     registerNotifications()
@@ -125,6 +141,8 @@ const { data: navigation } = await useFetch(config.NAVIGATION_API)
 // update the state with the navigation data
 let navigationState = useNavigation()
 navigationState.value = navigation.value
+
+const isRefreshing = ref(false)
 </script>
 
 <template>
@@ -208,6 +226,19 @@ navigationState.value = navigation.value
             {{ Capacitor.isPluginAvailable('Camera') }}
           </h6>
         </div>
+
+        <Transition name="refresh">
+          <div
+            v-if="isRefreshing"
+            class="fixed flex align-items-center justify-content-center w-full mt-2"
+          >
+            <i
+              class="pi pi-spin pi-spinner text-white text-lg mr-2"
+              style="font-size: 2rem"
+            ></i>
+            <p>REFRESHING</p>
+          </div>
+        </Transition>
         <slot />
       </div>
     </main>
@@ -217,6 +248,17 @@ navigationState.value = navigation.value
 </template>
 
 <style lang="scss">
+.refresh-enter-active,
+.refresh-leave-active {
+  transition: opacity 1s ease;
+}
+
+.refresh-enter-from {
+  opacity: 0;
+}
+.refresh-leave-to {
+  opacity: 0;
+}
 .dots {
   opacity: 0.5;
   background-image: radial-gradient(

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -250,7 +250,7 @@ const isRefreshing = ref(false)
 <style lang="scss">
 .refresh-enter-active,
 .refresh-leave-active {
-  transition: opacity 1s ease;
+  transition: opacity 0.5s ease;
 }
 
 .refresh-enter-from {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -105,6 +105,13 @@ const checkAppLaunchUrl = async () => {
 onBeforeMount(() => {
   //initially load all the streams
   updateAllLiveStreams()
+  //refresh data every time the tab is in focus
+  // document.addEventListener('visibilitychange', () => {
+  //   if (!document.hidden) {
+  //     updateAllLiveStreams()
+  //   }
+  // })
+
   if (isApp.value) {
     registerNotifications()
     addListeners()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default {
-  modules: ['@nuxtjs/ionic'],
+  modules: ['@nuxtjs/ionic', '@nuxtjs/device'],
   ssr: process.env.ISAPP === 'false' ? true : false,
   app: {
     head: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wnyc-vue-3",
+  "name": "wnyc-vue3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -21,6 +21,7 @@
         "primeflex": "^3.3.0"
       },
       "devDependencies": {
+        "@nuxtjs/device": "^3.1.0",
         "@nuxtjs/ionic": "^0.8.1",
         "date-fns": "^2.29.3",
         "howler": "^2.2.3",
@@ -3108,6 +3109,16 @@
         "vue-tsc": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nuxtjs/device": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/device/-/device-3.1.0.tgz",
+      "integrity": "sha512-jXWCVuPmzsGpn86GTA9/TOmfWulf9h3r2g6o5LpoZk4P1a9McMlpbDiaMPmyG5erfCj6H+XoZ6HBPCN9DtoCDA==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/kit": "^3.0.0-rc.13",
+        "defu": "^6.1.0"
       }
     },
     "node_modules/@nuxtjs/ionic": {
@@ -6884,9 +6895,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.310",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.310.tgz",
-      "integrity": "sha512-/xlATgfwkm5uDDwLw5nt/MNEf7c1oazLURMZLy39vOioGYyYzLWIDT8fZMJak6qTiAJ7udFTy7JG7ziyjNutiA=="
+      "version": "1.4.311",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
+      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw=="
     },
     "node_modules/elementtree": {
       "version": "0.1.7",
@@ -17751,6 +17762,16 @@
         }
       }
     },
+    "@nuxtjs/device": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/device/-/device-3.1.0.tgz",
+      "integrity": "sha512-jXWCVuPmzsGpn86GTA9/TOmfWulf9h3r2g6o5LpoZk4P1a9McMlpbDiaMPmyG5erfCj6H+XoZ6HBPCN9DtoCDA==",
+      "dev": true,
+      "requires": {
+        "@nuxt/kit": "^3.0.0-rc.13",
+        "defu": "^6.1.0"
+      }
+    },
     "@nuxtjs/ionic": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/ionic/-/ionic-0.8.1.tgz",
@@ -20567,9 +20588,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.310",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.310.tgz",
-      "integrity": "sha512-/xlATgfwkm5uDDwLw5nt/MNEf7c1oazLURMZLy39vOioGYyYzLWIDT8fZMJak6qTiAJ7udFTy7JG7ziyjNutiA=="
+      "version": "1.4.311",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
+      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw=="
     },
     "elementtree": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "generate-splash": "node assets/copyToAssets.js && npx capacitor-assets generate"
   },
   "devDependencies": {
+    "@nuxtjs/device": "^3.1.0",
     "@nuxtjs/ionic": "^0.8.1",
     "date-fns": "^2.29.3",
     "howler": "^2.2.3",


### PR DESCRIPTION
refresh strategy in place

I added a refreshing indicator for testing. It is a fixed element at the top below the header.

On desktop, when a user switches back to the tab, it will fetch all the data again (visibilitychange event)
on Desktop, when a users mouse enters the website window, it will fetch the data again. (pointerenter event)

on mobile, when the user switches to the sites tab, opens the browser on the site tab or lands on the browser when app switching, it will fetch all the data again. (visibilitychange event)

I think this covers most user situations without triggering a million fetches.