### PR TITLE
add some dummy API endpoints

### DIFF
--- a/server/api/homepage.ts
+++ b/server/api/homepage.ts
@@ -1,0 +1,35 @@
+const config = useRuntimeConfig()
+import axios from 'axios'
+
+const linkMapper = (link: any) => {
+	return {title: link.value.title, url: link.value.url}
+}
+
+/**
+ * Compress and simplify the global nav data.
+ * Reachable /api/homepage
+ */
+export default defineEventHandler(async (event) => {
+	const res = await axios(config.public.NAVIGATION_API)
+	// console.log(res.data)
+
+	const headerLinks = res.data.primary_navigation.map(linkMapper)
+	const footer1 = res.data.primary_footer_links.map(linkMapper)
+	const footer2 = res.data.secondary_footer_links.map(linkMapper)
+	const legalLinks = res.data.legal_links.map(linkMapper)
+
+	return {
+		// nav: res.data,
+		copyright: res.data.copyright_year,
+		description: res.data.property_description,
+		sponser: {
+			title: "WNYC is supported by the JLGreene Foundation",
+            url: "https://jlgreene.org/"
+		},
+		headerNav: headerLinks,
+		legalLinks: legalLinks,
+		footer1: footer1,
+		footer2: footer2
+	}
+  })
+  

--- a/server/api/userprofile/[email].ts
+++ b/server/api/userprofile/[email].ts
@@ -1,0 +1,14 @@
+/**
+ * Stub user profile service
+ * donor value is hard-coded to true iff email is bono ;)
+ * URL structure will be like /api/userprofile/tbono@wnyc.org
+ */
+export default defineEventHandler(async (event) => {
+	console.log(event)
+	const email = event.context.params.email
+	return {
+		email: email,
+		isDonor: "tbono@wnyc.org" === email,
+		defaultStream: "WNYCAM"
+	}
+})


### PR DESCRIPTION
I've added two endpoints as examples. /api/homepage which is just a refined version of the aviary nav endpoint and another for /api/userprofile/[email] which is just stubbed with hard-coded data