### PR TITLE
Bono/app testing

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -44,6 +44,9 @@ useHead({
     height=&quot;0&quot; width=&quot;0&quot; style=&quot;display:none;visibility:hidden&quot;></iframe>`,
     },
   ],
+  bodyAttrs: {
+    class: 'safe-area-padding',
+  },
 })
 
 // handles the permissions for push notifications in the app

--- a/app.vue
+++ b/app.vue
@@ -279,6 +279,7 @@ useHead({
 
 <style lang="scss">
 #settings-sidebar {
+  padding-top: env(safe-area-inset-top);
   background-color: var(--background2);
   .p-sidebar-header {
     padding: 0.75rem 0.75rem 0.75rem 1.25rem;

--- a/assets/scss/cssvars.scss
+++ b/assets/scss/cssvars.scss
@@ -2,7 +2,7 @@ $maxWidth: 1440px;
 $contentWidth: 1200px;
 $thinContentWidth: 768px;
 $headerHeight: 64px;
-$bottomMenuHeight: 60px;
+$bottomMenuHeight: 80px;
 $playerHeight: 100px;
 $toolsBreakPoint: 472px;
 

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -68,9 +68,9 @@ body {
   background-color: transparentize(#ffffff, 0.1);
   backdrop-filter: blur(5px);
 }
-.safe-area-padding {
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-}
+// .safe-area-padding {
+//   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+// }
 
 section {
   width: 100%;

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -67,9 +67,6 @@ body {
   z-index: 9999;
   background: var(--header-background);
 }
-// .safe-area-padding {
-//   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-// }
 
 section {
   width: 100%;

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -65,8 +65,7 @@ body {
   left: 0;
   right: 0;
   z-index: 9999;
-  background-color: transparentize(#ffffff, 0.1);
-  backdrop-filter: blur(5px);
+  background: var(--header-background);
 }
 // .safe-area-padding {
 //   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -68,6 +68,9 @@ body {
   background-color: transparentize(#ffffff, 0.1);
   backdrop-filter: blur(5px);
 }
+.safe-area-padding {
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
 
 section {
   width: 100%;

--- a/components/AudioPlayer.vue
+++ b/components/AudioPlayer.vue
@@ -268,8 +268,13 @@ watch(isEpisodePlaying, (e) => {
       border: 1px solid var(--background2--500);
     }
   }
-  .template-blank .persistent-player {
-    bottom: 0;
+  .template-blank {
+    .persistent-player {
+      bottom: 0;
+    }
+    .expandedFooter {
+      bottom: 0 !important;
+    }
   }
 }
 </style>
@@ -278,13 +283,19 @@ watch(isEpisodePlaying, (e) => {
 .persistent-player {
   .expandedFooter {
     background-color: var(--red-500);
-
     display: block;
     position: fixed;
-    height: 100px;
+    height: 45px;
     bottom: 0;
     left: 0;
     width: 100%;
+    transition: bottom $transitionDuration;
+    -webkit-transition: bottom $transitionDuration;
+  }
+  &.expanded {
+    .expandedFooter {
+      bottom: $bottomMenuHeight;
+    }
   }
 }
 .player-enter-active {

--- a/components/BottomMenu.vue
+++ b/components/BottomMenu.vue
@@ -76,6 +76,7 @@ watch(
     width: 100%;
     display: flex;
     justify-content: space-around;
+    align-items: flex-start;
     .p-button {
       border-radius: 0 !important;
       font-size: 13px;

--- a/components/Settings.vue
+++ b/components/Settings.vue
@@ -415,7 +415,7 @@ const onClickDisabled = (elm = 'field') => {
   }
   .settings-message {
     position: absolute;
-    top: 0;
+    top: calc(env(safe-area-inset-top) + 40px);
     left: 0;
     right: 0;
   }

--- a/components/TheHeader.vue
+++ b/components/TheHeader.vue
@@ -62,8 +62,8 @@ const settingsSideBar = useSettingSideBar()
 <style lang="scss">
 .the-header {
   background: var(--header-background);
-  backdrop-filter: blur(5px);
-  border: 1px solid var(--shade-400);
+  //backdrop-filter: blur(5px);
+  border-bottom: 1px solid var(--shade-400);
 
   .pi-bars {
     color: var(--text-color);

--- a/layouts/blank.vue
+++ b/layouts/blank.vue
@@ -69,15 +69,4 @@ body {
     ); // account for the sticky bottom menu
   }
 }
-
-.top-safe-cover {
-  height: env(safe-area-inset-top);
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 9999;
-  background-color: transparentize(#de1e3d, 0.1);
-  backdrop-filter: blur(5px);
-}
 </style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
     layoutTransition: true,
     head: {
       meta: [
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { name: 'viewport', content: 'viewport-fit=cover, width=device-width, initial-scale=1' },
         { name: 'msapplication-TileColor', content: '#de1e3d' },
         { name: 'theme-color', content: '#de1e3d' }
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@hypernym/nuxt-gsap": "^2.2.2",
         "@nuxt/image": "^1.0.0-rc.1",
         "@nuxtjs/supabase": "^0.3.8",
-        "@nypublicradio/nypr-design-system-vue3": "^2.0.52",
+        "@nypublicradio/nypr-design-system-vue3": "^2.0.53",
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.3",
         "capacitor-native-settings": "5.0.0",
@@ -3218,9 +3218,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "2.0.52",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.52/a797e4cfb05946d986512c13aa2ec4fd03b3a6fc",
-      "integrity": "sha512-WKsJivkbDyKbV88lKss6HOLKvsHWTB3GGpgJxi23kd0AXpiIzgoQmUZAC/jeYCA6PrYc0DUo1gcISx3X35Q+TA==",
+      "version": "2.0.53",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.53/a51b24d47b9a03e3265e512ec74fc073585ef717",
+      "integrity": "sha512-za7+ciVIIHFSdCdmzGCtsgNnnaOLo/r3y2c3A6aHYSuFdOgArs78wj+BU8Gm2ylg8DwcbbCjLVnX9D0PIwGC1Q==",
       "dependencies": {
         "@nuxt/image": "rc",
         "@nuxtjs/supabase": "^0.3.7",
@@ -17760,9 +17760,9 @@
       }
     },
     "@nypublicradio/nypr-design-system-vue3": {
-      "version": "2.0.52",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.52/a797e4cfb05946d986512c13aa2ec4fd03b3a6fc",
-      "integrity": "sha512-WKsJivkbDyKbV88lKss6HOLKvsHWTB3GGpgJxi23kd0AXpiIzgoQmUZAC/jeYCA6PrYc0DUo1gcISx3X35Q+TA==",
+      "version": "2.0.53",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.53/a51b24d47b9a03e3265e512ec74fc073585ef717",
+      "integrity": "sha512-za7+ciVIIHFSdCdmzGCtsgNnnaOLo/r3y2c3A6aHYSuFdOgArs78wj+BU8Gm2ylg8DwcbbCjLVnX9D0PIwGC1Q==",
       "requires": {
         "@nuxt/image": "rc",
         "@nuxtjs/supabase": "^0.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@hypernym/nuxt-gsap": "^2.2.2",
         "@nuxt/image": "^1.0.0-rc.1",
         "@nuxtjs/supabase": "^0.3.8",
-        "@nypublicradio/nypr-design-system-vue3": "^2.0.53",
+        "@nypublicradio/nypr-design-system-vue3": "^2.0.54",
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.3",
         "capacitor-native-settings": "5.0.0",
@@ -3218,9 +3218,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "2.0.53",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.53/a51b24d47b9a03e3265e512ec74fc073585ef717",
-      "integrity": "sha512-za7+ciVIIHFSdCdmzGCtsgNnnaOLo/r3y2c3A6aHYSuFdOgArs78wj+BU8Gm2ylg8DwcbbCjLVnX9D0PIwGC1Q==",
+      "version": "2.0.54",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.54/2e962bab10c2f20f2982433b7bcdadce8a706f9d",
+      "integrity": "sha512-4XG5gl86FAHouFkuTj9nUy/AyDwbI7ITjlAquUleCU6LEIVF3n5hIF9akqmneDz/z61+jIVouINP3/sl8NMsfQ==",
       "dependencies": {
         "@nuxt/image": "rc",
         "@nuxtjs/supabase": "^0.3.7",
@@ -17760,9 +17760,9 @@
       }
     },
     "@nypublicradio/nypr-design-system-vue3": {
-      "version": "2.0.53",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.53/a51b24d47b9a03e3265e512ec74fc073585ef717",
-      "integrity": "sha512-za7+ciVIIHFSdCdmzGCtsgNnnaOLo/r3y2c3A6aHYSuFdOgArs78wj+BU8Gm2ylg8DwcbbCjLVnX9D0PIwGC1Q==",
+      "version": "2.0.54",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.0.54/2e962bab10c2f20f2982433b7bcdadce8a706f9d",
+      "integrity": "sha512-4XG5gl86FAHouFkuTj9nUy/AyDwbI7ITjlAquUleCU6LEIVF3n5hIF9akqmneDz/z61+jIVouINP3/sl8NMsfQ==",
       "requires": {
         "@nuxt/image": "rc",
         "@nuxtjs/supabase": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hypernym/nuxt-gsap": "^2.2.2",
     "@nuxt/image": "^1.0.0-rc.1",
     "@nuxtjs/supabase": "^0.3.8",
-    "@nypublicradio/nypr-design-system-vue3": "^2.0.53",
+    "@nypublicradio/nypr-design-system-vue3": "^2.0.54",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.3",
     "capacitor-native-settings": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hypernym/nuxt-gsap": "^2.2.2",
     "@nuxt/image": "^1.0.0-rc.1",
     "@nuxtjs/supabase": "^0.3.8",
-    "@nypublicradio/nypr-design-system-vue3": "^2.0.52",
+    "@nypublicradio/nypr-design-system-vue3": "^2.0.53",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.3",
     "capacitor-native-settings": "5.0.0",

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -25,7 +25,6 @@ definePageMeta({
       </ClientOnly> -->
 
     <LiveFeature />
-    <!-- <StreamSwitcher /> -->
     <!-- <div class="grid gap-3">
         <div class="col">
           <MainPlayer />
@@ -65,9 +64,3 @@ definePageMeta({
     </section>
   </div>
 </template>
-
-<style lang="scss">
-.top-safe-cover {
-  background: var(--dark-blue-500);
-}
-</style>

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -65,3 +65,9 @@ definePageMeta({
     </section>
   </div>
 </template>
+
+<style lang="scss">
+.top-safe-cover {
+  background: var(--dark-blue-500);
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -71,7 +71,7 @@ onMounted(() => {
 .loading-holder {
   display: flex;
   position: absolute;
-  height: 100vh;
+  height: 100dvh;
   width: 100vw;
   left: 0;
   right: 0;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,42 +25,44 @@ onMounted(() => {
       <section v-if="isLoading" class="loading-holder">
         <WnycLoader class="loader-anim" />
       </section>
-      <section v-else class="index-page flex flex-column pb-8">
-        <WnycLogo class="w-12rem m-auto my-7" />
-        <h1 class="headline">What's new?</h1>
-        <ul class="list m-auto mt-4 mb-7">
-          <li>Listen to WNYC's Live Radio Stream</li>
-          <li>Get the latest news updates</li>
-          <li>Stream your favorite podcasts</li>
-          <li>Read local news from Gothamist</li>
-          <li>Follow your favorite shows</li>
-        </ul>
-        <h1 class="headline mb-4">Get started!</h1>
-        <div class="text-center flex flex-column gap-3">
-          <VFlexibleLink raw to="/signup" class="w-13rem m-auto">
-            <Button
-              class="w-full"
-              label="Create Free Account"
-              rounded
-              size="small"
-            />
-          </VFlexibleLink>
-          <p>or</p>
-          <VFlexibleLink raw to="/login" class="w-13rem m-auto">
-            <Button
-              class="w-full"
-              label="Log in"
-              rounded
-              size="small"
-              severity="secondary"
-            />
-          </VFlexibleLink>
-          <p>
-            <VFlexibleLink to="/home">Skip this</VFlexibleLink>, I'll create an
-            account later.
-          </p>
-        </div>
-      </section>
+      <div v-else class="index-page flex">
+        <section class="flex flex-column pb-6">
+          <WnycLogo class="w-12rem m-auto mb-7 flex-none" />
+          <h1 class="headline">What's new?</h1>
+          <ul class="list m-auto mt-4 mb-7">
+            <li>Listen to WNYC's Live Radio Stream</li>
+            <li>Get the latest news updates</li>
+            <li>Stream your favorite podcasts</li>
+            <li>Read local news from Gothamist</li>
+            <li>Follow your favorite shows</li>
+          </ul>
+          <h1 class="headline mb-4">Get started!</h1>
+          <div class="text-center flex flex-column gap-3">
+            <VFlexibleLink raw to="/signup" class="w-13rem m-auto">
+              <Button
+                class="w-full"
+                label="Create Free Account"
+                rounded
+                size="small"
+              />
+            </VFlexibleLink>
+            <p>or</p>
+            <VFlexibleLink raw to="/login" class="w-13rem m-auto">
+              <Button
+                class="w-full"
+                label="Log in"
+                rounded
+                size="small"
+                severity="secondary"
+              />
+            </VFlexibleLink>
+            <p>
+              <VFlexibleLink to="/home">Skip this</VFlexibleLink>, I'll create
+              an account later.
+            </p>
+          </div>
+        </section>
+      </div>
     </Transition>
   </div>
 </template>
@@ -86,6 +88,7 @@ onMounted(() => {
   }
 }
 .index-page {
+  height: 100dvh;
   .headline {
     font-size: 30px;
     text-align: center;

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -13,7 +13,6 @@ definePageMeta({
   },
 })
 
-const router = useRouter()
 const client = useSupabaseClient()
 const config = useRuntimeConfig()
 useHead({
@@ -84,8 +83,3 @@ useHead({
     </section>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.login {
-}
-</style>


### PR DESCRIPTION
- top status bar issue resolved
- setting menu status bar issue resolved
- expanded player status bar issue resolved
- VSmartHeader safe-area css added
- made the bottom menu 80px instead of 60px and made the buttons hug the top as they were colliding with iOS bottom line
- centered content on index page
- expanded footer in the AudioPlayer extended-view bottom position dynamic based on the template being used (bottom menu is present)
- setting message top offset with safe-area
- removed left, right and top border on the header