### PR TITLE
Consolidated the show data call.

### DIFF
--- a/server/api/show/[showslug].ts
+++ b/server/api/show/[showslug].ts
@@ -24,15 +24,34 @@ const getEpisodes = async (slug: string, type: string, page?: string) => {
     }
 }
 
+const getShow = async (slug: string) => {
+    try {
+        const option = {
+            method: 'GET',
+            url: `${config.public.PUBLISHER_BASE_API}v4/shows/${slug}/`
+        };
+        const res = await axios(option);
+        return humps.camelizeKeys(res.data);
+    } catch (e) {
+        //console.log(e);
+    }
+}
+
 export default defineEventHandler(async (event) => {
     //Fetching slug and type from the path params
     const slug: string | undefined = event?.context?.params?.showslug;
-    const type: string | undefined = event?.context?.params?.showtype;
     //Fetching query params
     const query = getQuery(event);
     const page: string | undefined = Array.isArray(query.page) ? query.page[0] : query.page;
-    if (slug && type) {
-        return getEpisodes(slug, type, page);
+    if (slug) {
+        // Get show details
+        const show = await getShow(slug);
+        const episodes = await getEpisodes(slug, show?.data.type, page);
+
+        return {
+            show: show,
+            episodes: episodes
+        }
     }
     return null;
 });


### PR DESCRIPTION
Consolidate show and episode data from a single call. Remove the need to have to pass the type as part of the request as it's fetched in the call that pulls the show data.