### PR TITLE
WNYC-70

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -430,3 +430,8 @@ a:visited {
     border: transparent;
   }
 }
+
+.p-scrolltop {
+  margin-bottom: $bottomMenuHeight;
+  border-radius: 50%;
+}

--- a/components/EpisodeItem.vue
+++ b/components/EpisodeItem.vue
@@ -180,7 +180,7 @@ const hasAudio = computed(() => {
         style="min-height: 72px; min-width: 72px"
       />
       <div class="flex gap-1 flex-column align-items-start">
-        <h2 class="text-sm line-height-2">{{ props.data.title }}</h2>
+        <h2 class="text-sm line-height-2 truncate t2lines">{{ props.data.title }}</h2>
         <p>{{ props.data.org }}</p>
         <div class="article-metadata flex flex-column gap-1">
           <PipeData class="text-xs" :hide-pipe="!hasAudio">

--- a/pages/browse/shows/[slug].vue
+++ b/pages/browse/shows/[slug].vue
@@ -199,6 +199,9 @@ watch(show, () => {
       />
       <skeleton-episode-item v-else v-for="(show, index) in 10" :key="`sk1-${index}`" />
     </div>
+    <Transition name="fade">
+      <ScrollTop :threshold="600" />
+    </Transition>
   </section>
 </template>
 

--- a/pages/browse/shows/episode/[slug].vue
+++ b/pages/browse/shows/episode/[slug].vue
@@ -154,7 +154,12 @@ watch(episode, () => {
         :alt="episodeData?.image.altText"
         class="episode-page-image mb-2"
       />
-      <Skeleton v-else borderRadius="0px" height="auto" class="episode-page-image mb-2" />
+      <Skeleton
+        v-else
+        borderRadius="0px"
+        height="auto"
+        class="episode-page-image mb-2 opacity-60"
+      />
       <v-image
         v-if="episodeData"
         :src="episodeData?.headers.brand.logoImage.template"
@@ -170,7 +175,7 @@ watch(episode, () => {
         borderRadius="0px"
         height="70px"
         width="70px"
-        class="episode-page-show-image mb-2"
+        class="episode-page-show-image mb-2 absolute"
       />
     </div>
     <div v-if="episodeData">
@@ -187,12 +192,15 @@ watch(episode, () => {
         <div class="flex align-items-center justify-content-between">
           <div>
             <PlayButton
-              v-if="!episodeData?.segments"
+              v-if="!episodeData?.segments && episodeData?.audio"
               :label="getMinutes(episodeData?.estimatedDuration, 1)"
               :file="episodeData?.audio"
               @onClick="togglePlay(episodeData)"
               class=""
             />
+            <div v-else class="font-bold text-red-500">
+              <i class="pi pi-exclamation-triangle mr-1"></i>No Audio
+            </div>
           </div>
           <div class="flex gap-3">
             <Button
@@ -282,6 +290,9 @@ watch(episode, () => {
       </div>
       <skeleton-text :lines="6" class="mt-1" />
     </section>
+    <Transition name="fade">
+      <ScrollTop :threshold="600" />
+    </Transition>
   </div>
 </template>
 

--- a/pages/staff/[slug].vue
+++ b/pages/staff/[slug].vue
@@ -111,6 +111,9 @@ const routeBack = () => {
         </Button>
       </div>
     </div>
+    <Transition name="fade">
+      <ScrollTop :threshold="600" />
+    </Transition>
   </section>
 </template>
 

--- a/pages/story/[slug].vue
+++ b/pages/story/[slug].vue
@@ -234,6 +234,9 @@ watch(storyData, async () => {
       <h2 class="mb-3">Top Stories From Gothamist</h2>
       <TopStories :articles="topStories" />
     </section>
+    <Transition name="fade">
+      <ScrollTop :threshold="600" />
+    </Transition>
   </div>
 </template>
 

--- a/plugins/primevue.js
+++ b/plugins/primevue.js
@@ -25,6 +25,7 @@ import Divider from 'primevue/divider'
 import Message from 'primevue/message'
 import ProgressSpinner from 'primevue/progressspinner'
 import Ripple from 'primevue/ripple'
+import ScrollTop from 'primevue/scrolltop'
 import Slider from 'primevue/slider'
 //import Tooltip from 'primevue/tooltip'
 
@@ -55,6 +56,7 @@ export default defineNuxtPlugin(nuxtApp => {
     nuxtApp.vueApp.component('ProgressSpinner', ProgressSpinner)
     nuxtApp.vueApp.component('Dialog', Dialog)
     nuxtApp.vueApp.component('ProgressBar', ProgressBar)
+    nuxtApp.vueApp.component('ScrollTop', ScrollTop)
     nuxtApp.vueApp.component('Slider', Slider)
     // nuxtApp.vueApp.component('Tooltip', Tooltip)
     // nuxtApp.vueApp.directive('tooltip', Tooltip)

--- a/server/api/show/episode/[episodeslug].ts
+++ b/server/api/show/episode/[episodeslug].ts
@@ -14,7 +14,7 @@ const getEpisode = async (slug: string) => {
         };
         const res = await axios(option);
         let resData = humps.camelizeKeys(res.data).data;
-
+        //console.log('resData', resData)
         // fallback image to show image when no image is available
         resData.attributes.imageMain = resData.attributes.imageMain ? resData.attributes.imageMain : resData.attributes.headers.brand.logoImage ? resData.attributes.headers.brand.logoImage : { template: FALLBACKIMAGE };
 


### PR DESCRIPTION
- back to top button added to the slug pages
- when the sound file is not present, it can’t read the duration. when this happens, I replaced the play button with a “! No Sound“ , but we will probably eventually remove the episode if an audio file is not present.
