### PR TITLE
Bono/backlog

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -456,6 +456,14 @@ a:visited {
   }
 }
 
+// dotmenu pi icons
+.p-dropdown-item {
+  .pi {
+    font-size: 24px;
+    padding: 0 4px;
+  }
+}
+
 @mixin cardTitle() {
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/components/AudioPlayer.vue
+++ b/components/AudioPlayer.vue
@@ -18,7 +18,7 @@ import {
   useCurrentEpisodeProgress,
   useSkipAheadTrigger,
   useSkipBackTrigger,
-  usePlayerSeek,
+  //usePlayerSeek,
   useIsNetworkConnected,
   //useAdvertisingRestriction,
   useAdvertisingId,
@@ -60,7 +60,7 @@ const isPlayerMinimized = useIsPlayerMinimized()
 const isStreamLoading = useIsStreamLoading()
 const skipAheadTrigger = useSkipAheadTrigger()
 const skipBackTrigger = useSkipBackTrigger()
-const playerSeek = usePlayerSeek()
+//const playerSeek = usePlayerSeek()
 const currentEpisodeDuration = useCurrentEpisodeDuration()
 const isNetworkConnected = useIsNetworkConnected()
 const advertisingId = useAdvertisingId()
@@ -128,15 +128,15 @@ watch(skipAheadTrigger, () => {
 watch(skipBackTrigger, () => {
   if (playerRef.value) playerRef.value.skipBack()
 })
-watch(
-  playerSeek,
-  (e) => {
-    if (playerRef.value) {
-      playerRef.value.scrubTimelineEnd(e.time)
-    }
-  },
-  { deep: true }
-)
+// watch(
+//   playerSeek,
+//   (e) => {
+//     if (playerRef.value) {
+//       playerRef.value.scrubTimelineEnd(e.time)
+//     }
+//   },
+//   { deep: true }
+// )
 
 // if the route changes, and the expanded player is expanded, close the expanded player
 watch(
@@ -191,7 +191,7 @@ const togglePlayHere = (e) => {
 //remoteControl.requestGoogleCast()
 //}
 
-/* 
+/*
 the url that comes down from publisher is in currentEpisode.value
 then if we are in the App env, we check if the url has a param(a "?" already)
 then we grab the asID and the restriction value (0 default or 1)

--- a/components/EpisodeItem.vue
+++ b/components/EpisodeItem.vue
@@ -83,7 +83,7 @@ watch(
         ? await fetchDuration(props.data.audio)
         : props.data.estimatedDuration
   },
-  { immediate: true, deep: true }
+  { immediate: true }
 )
 
 // const handleAddToQueue = (bucketItem) => {

--- a/components/FileSystem.vue
+++ b/components/FileSystem.vue
@@ -16,17 +16,18 @@ const isNetworkConnected = useIsNetworkConnected()
 const used = ref(0)
 const granted = ref(0)
 
-watch(
-  fileSystem,
-  (/* value */) => {
-    navigator.webkitPersistentStorage.queryUsageAndQuota((usedBytes, grantedBytes) => {
-      //console.log('we are using ', usedBytes, ' of ', grantedBytes, 'bytes')
-      used.value = usedBytes
-      granted.value = grantedBytes
-    })
-  },
-  { deep: true }
-)
+// get the used and granted storage
+// watch(
+//   fileSystem,
+//   (/* value */) => {
+//     navigator.webkitPersistentStorage.queryUsageAndQuota((usedBytes, grantedBytes) => {
+//       //console.log('we are using ', usedBytes, ' of ', grantedBytes, 'bytes')
+//       used.value = usedBytes
+//       granted.value = grantedBytes
+//     })
+//   },
+//   { deep: true }
+// )
 
 // handle the routing of the stored audio file IF network is connected
 const handleRoute = (file) => {

--- a/components/FileSystem.vue
+++ b/components/FileSystem.vue
@@ -2,19 +2,19 @@
 import { goToEpisodePage, goToStoryPage, trackClickEvent } from "~/utilities/helpers"
 import { deleteDirectory } from "~/utilities/file-system"
 import {
-  useFileSystem,
+  //useFileSystem,
   useFileSystemLS,
   useIsNetworkConnected,
 } from "~/composables/states"
 
 import { mediaTypes } from "~/composables/globals"
 
-const fileSystem = useFileSystem()
+//const fileSystem = useFileSystem()
 const fileSystemLS = useFileSystemLS()
 const isNetworkConnected = useIsNetworkConnected()
 
-const used = ref(0)
-const granted = ref(0)
+// const used = ref(0)
+// const granted = ref(0)
 
 // get the used and granted storage
 // watch(

--- a/components/PlayAndSkipButtons.vue
+++ b/components/PlayAndSkipButtons.vue
@@ -5,6 +5,7 @@ import {
   useSkipAheadTrigger,
   useSkipBackTrigger,
   useIsLiveStream,
+  useIsStreamLoading,
 } from "~/composables/states"
 
 const props = defineProps({
@@ -22,6 +23,7 @@ const togglePlayTrigger = useTogglePlayTrigger()
 const skipAheadTrigger = useSkipAheadTrigger()
 const skipBackTrigger = useSkipBackTrigger()
 const isLiveStream = useIsLiveStream()
+const isStreamLoading = useIsStreamLoading()
 
 const emit = defineEmits(["beforeTogglePlay", "beforeSkipAhead", "beforeSkipBack"])
 
@@ -55,12 +57,23 @@ const isLive = computed(() => {
         <template #icon> <Previous10 /></template>
       </Button>
     </template>
-    <Button v-if="isEpisodePlaying" severity="secondary" rounded @click="togglePlay">
+    <Button
+      v-if="isEpisodePlaying && !isStreamLoading"
+      severity="secondary"
+      rounded
+      @click="togglePlay"
+    >
       <template #icon> <PauseIcon /></template>
     </Button>
-    <Button v-else severity="secondary" rounded @click="togglePlay">
+    <Button v-else-if="!isStreamLoading" severity="secondary" rounded @click="togglePlay">
       <template #icon> <PlayIcon /></template>
     </Button>
+    <Button v-if="isStreamLoading" severity="secondary" rounded>
+      <template #icon>
+        <i v-if="isStreamLoading" class="pi pi-spin pi-spinner"></i
+      ></template>
+    </Button>
+
     <template v-if="!props.hideSkip">
       <Button v-if="!isLive" severity="secondary" rounded @click="skipAhead">
         <template #icon> <Next10 /></template>

--- a/components/Settings.vue
+++ b/components/Settings.vue
@@ -11,7 +11,6 @@ import {
 } from "~/composables/states.ts"
 import VInputSwitch from "@nypublicradio/nypr-design-system-vue3/v2/src/components/VInputSwitch.vue"
 import { Preferences } from "@capacitor/preferences"
-import { is } from "date-fns/locale"
 
 const currentUser = useCurrentUser()
 const currentUserProfile = useCurrentUserProfile()
@@ -129,7 +128,6 @@ const onUpdateStation = () => {
   )
   // if not playing, update the live stream so the home page updates with the new default stream
   if (!isLiveStream.value) {
-    alert("update")
     updateLiveStream(currentUserProfile.value.default_live_stream.slug)
   }
 }

--- a/components/Settings.vue
+++ b/components/Settings.vue
@@ -7,14 +7,17 @@ import {
   useCurrentUser,
   useCurrentUserProfile,
   useEditProfileSideBar,
+  useIsLiveStream,
 } from "~/composables/states.ts"
 import VInputSwitch from "@nypublicradio/nypr-design-system-vue3/v2/src/components/VInputSwitch.vue"
 import { Preferences } from "@capacitor/preferences"
+import { is } from "date-fns/locale"
 
 const currentUser = useCurrentUser()
 const currentUserProfile = useCurrentUserProfile()
 const textSizeOptions = useTextSizeOption()
 const editProfileSideBar = useEditProfileSideBar()
+const isLiveStream = useIsLiveStream()
 
 const allCurrentStations = useAllCurrentStations()
 const stationsMenuData = ref([])
@@ -124,6 +127,11 @@ const onUpdateStation = () => {
     "Settings Sidebar - Listening Preferences",
     currentUserProfile.value.default_live_stream.station
   )
+  // if not playing, update the live stream so the home page updates with the new default stream
+  if (!isLiveStream.value) {
+    alert("update")
+    updateLiveStream(currentUserProfile.value.default_live_stream.slug)
+  }
 }
 
 const accountHeader = computed(() => {

--- a/components/StoryItem.vue
+++ b/components/StoryItem.vue
@@ -73,7 +73,7 @@ watch(
     estimatedDuration.value =
       typeof dur === "number" && dur !== 0 ? dur : await fetchDuration(props.data.audio)
   },
-  { immediate: false, deep: true }
+  { immediate: false }
 )
 // add item to favorites
 const handleAddToFavorites = (bucketItem) => {

--- a/components/WNYCFeatured.vue
+++ b/components/WNYCFeatured.vue
@@ -7,10 +7,8 @@ import {
   prepForPlayer,
 } from "~/utilities/helpers"
 import { useTogglePlayTrigger, useCurrentEpisode } from "~/composables/states"
-import { useToast } from "primevue/usetoast"
 import { fetchAndStoreMp3, isAlreadyDownloaded } from "~/utilities/file-system"
 import DownloadIcon from "~/components/icons/DownloadIcon.vue"
-const toast = useToast()
 const togglePlayTrigger = useTogglePlayTrigger()
 const currentEpisode = useCurrentEpisode()
 

--- a/components/WNYCFeatured.vue
+++ b/components/WNYCFeatured.vue
@@ -9,6 +9,7 @@ import {
 import { useTogglePlayTrigger, useCurrentEpisode } from "~/composables/states"
 import { useToast } from "primevue/usetoast"
 import { fetchAndStoreMp3, isAlreadyDownloaded } from "~/utilities/file-system"
+import DownloadIcon from "~/components/icons/DownloadIcon.vue"
 const toast = useToast()
 const togglePlayTrigger = useTogglePlayTrigger()
 const currentEpisode = useCurrentEpisode()
@@ -34,6 +35,7 @@ const getDotMenuItems = (bucketItem) => {
     {
       label: "Download",
       title: bucketItem.title,
+      customIcon: DownloadIcon,
       command: () => {
         handleDownload(bucketItem)
       },
@@ -41,19 +43,10 @@ const getDotMenuItems = (bucketItem) => {
     {
       label: "Copy embed code",
       title: bucketItem.title,
+      icon: "pi pi-code",
       embedCode: bucketItem.embedCode,
       command: () => {
         copyToClipBoard(bucketItem.embedCode)
-          ? toast.add({
-              severity: "info",
-              summary: "Embed code copied to clipboard",
-              life: 3000,
-            })
-          : toast.add({
-              severity: "error",
-              summary: "Copy to clipboard failed. Try again another time",
-              life: 3000,
-            })
         trackClickEvent(
           "Click Tracking - Audio Copy Embed Code",
           "Large Card",

--- a/components/saved/DynamicList.vue
+++ b/components/saved/DynamicList.vue
@@ -21,6 +21,7 @@ const props = defineProps({
 const client = useSupabaseClient()
 const savedItems = ref(null)
 const user = useCurrentUser()
+const pending = ref(false)
 const fetchError = ref(null)
 
 // determines what component to load based on the item type
@@ -74,6 +75,7 @@ const getFilteredItemsData = computed(() => {
 // retrieve item data
 const getItemsData = async () => {
   if (user.value) {
+    pending.value = true
     const { data, error } = props.typeFilter
       ? await getFilteredItemsData.value
       : await client
@@ -92,6 +94,7 @@ const getItemsData = async () => {
     } else {
       savedItems.value = null
     }
+    pending.value = false
     fetchError.value = error
     if (error) {
       console.error("favorited items error", error)
@@ -127,6 +130,6 @@ watch(
       <slot name="recent-episodes" :show="item" />
     </div>
   </div>
+  <slot v-if="!savedItems && !pending" name="empty" />
   <FetchError v-if="fetchError" @on-click="getItemsData" />
-  <slot v-else name="empty" />
 </template>

--- a/composables/data/liveStream.ts
+++ b/composables/data/liveStream.ts
@@ -1,4 +1,4 @@
-import { useCurrentEpisodeHolder, useAllCurrentStations, useCurrentUserProfile, } from '~/composables/states'
+import { useCurrentEpisodeHolder, useAllCurrentStations, useCurrentUserProfile, useGlobalToast } from '~/composables/states'
 import { saveRecentlyPlayed } from '~/utilities/helpers'
 
 
@@ -6,10 +6,21 @@ import { saveRecentlyPlayed } from '~/utilities/helpers'
 export async function updateLiveStream(slug: string) {
     const config = useRuntimeConfig()
     //BFF
-    const fetchData = await $fetch(`${config.public.BFF_URL}/api/whatson/${slug}`)
-    const currentEpisodeHolder = useCurrentEpisodeHolder()
-    currentEpisodeHolder.value = fetchData
-    saveRecentlyPlayed(currentEpisodeHolder.value, mediaTypes.LIVE)
+    try {
+        const fetchData = await $fetch(`${config.public.BFF_URL}/api/whatson/${slug}`)
+        const currentEpisodeHolder = useCurrentEpisodeHolder()
+        currentEpisodeHolder.value = fetchData
+        saveRecentlyPlayed(currentEpisodeHolder.value, mediaTypes.LIVE)
+    } catch (error) {
+        const globalToast = useGlobalToast()
+        globalToast.value = {
+            severity: "error",
+            summary: "Sorry. We are having trouble with the live stream. Please try again later.",
+            life: null,
+            closable: true,
+        }
+        console.error('error = ', error)
+    }
 }
 
 export async function updateAllLiveStreams() {
@@ -18,25 +29,36 @@ export async function updateAllLiveStreams() {
     const currentUserProfile = useCurrentUserProfile()
     const config = useRuntimeConfig()
     // BFF
-    const fetchingAll = await $fetch(`${config.public.BFF_URL}/api/streams`)
-    //console.log('fetchingAll = ', fetchingAll.value)
-    // set all streams
-    allCurrentStations.value = fetchingAll.filter(Boolean)
-    //allCurrentStations.value = allCurrentStationsImport
+    try {
+        const fetchingAll = await $fetch(`${config.public.BFF_URL}/api/streams`)
+        //console.log('fetchingAll = ', fetchingAll.value)
+        // set all streams
+        allCurrentStations.value = fetchingAll.filter(Boolean)
+        //allCurrentStations.value = allCurrentStationsImport
 
-    // set initial stream with the `currentStreamStation` value in the states.ts file
-    const initialStation = allCurrentStations.value.find(
-        (option) => {
-            //console.log('currentUserProfile.value  = ', currentUserProfile.value)
-            if (currentUserProfile.value) {
-                const profile = typeof currentUserProfile.value.default_live_stream === 'string' ? currentUserProfile.value.default_live_stream : currentUserProfile.value.default_live_stream.station
-                return option.station === profile
-            } else {
-                return null
+        // set initial stream with the `currentStreamStation` value in the states.ts file
+        const initialStation = allCurrentStations.value.find(
+            (option) => {
+                //console.log('currentUserProfile.value  = ', currentUserProfile.value)
+                if (currentUserProfile.value) {
+                    const profile = typeof currentUserProfile.value.default_live_stream === 'string' ? currentUserProfile.value.default_live_stream : currentUserProfile.value.default_live_stream.station
+                    return option.station === profile
+                } else {
+                    return null
+                }
             }
-        }
-    )
+        )
 
-    currentEpisodeHolder.value = initialStation
-    //console.log('currentEpisodeHolder STREAM= ', currentEpisodeHolder.value)
+        currentEpisodeHolder.value = initialStation
+        //console.log('currentEpisodeHolder STREAM= ', currentEpisodeHolder.value)
+    } catch (error) {
+        const globalToast = useGlobalToast()
+        globalToast.value = {
+            severity: "error",
+            summary: "Sorry. We are having trouble with the live stream. Please try again later.",
+            life: null,
+            closable: true,
+        }
+        console.error('error = ', error)
+    }
 }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Our app utilizes user tracking data to personalize your experience and provide relevant content. This data helps us understand your preferences and tailor our services to better suit your needs. Rest assured, we prioritize your privacy and adhere to strict data protection measures. Your information is securely handled and never shared with third parties without your explicit consent.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/middleware/checkAuthProvider.js
+++ b/middleware/checkAuthProvider.js
@@ -13,15 +13,15 @@ export default defineNuxtRouteMiddleware(async () => {
 
   // update the user's profile (name and image) if they signed up with google
   const updateUser = async () => {
-    if (currentUser.value.user_metadata.provider === 'google') {
+    if (user.data.session.user.app_metadata.provider === 'google') {
       await client
         .from('profiles')
         .update({
           updated_at: new Date().toISOString(),
-          name: currentUser.value.user_metadata.full_name,
-          avatar_image_url: currentUser.value.user_metadata.avatar_url,
+          name: user.data.session.user.user_metadata.full_name,
+          avatar_image_url: user.data.session.user.user_metadata.avatar_url,
         })
-        .match({ id: currentUser.value.id })
+        .match({ id: user.data.session.user.id })
     }
   }
 

--- a/pages/browse/index.vue
+++ b/pages/browse/index.vue
@@ -85,7 +85,7 @@ onMounted(() => {
         />
       </Head>
     </Html>
-    <section class="search">
+    <section class="search z-2">
       <span class="p-input-icon-left w-full">
         <i v-if="isSearching" class="pi pi-spin pi-spinner text-color" />
         <i v-else class="pi pi-search text-color" />

--- a/pages/browse/shows/[slug].vue
+++ b/pages/browse/shows/[slug].vue
@@ -13,7 +13,7 @@ import {
   hasAudio,
   addToFavorites,
 } from "~/utilities/helpers"
-import { useCurrentUser, useIsEpisodePlaying } from "~/composables/states"
+import { useCurrentUser, useIsEpisodePlaying, useGlobalToast } from "~/composables/states"
 import { FALLBACKIMAGEEP } from "~/composables/globals"
 
 const config = useRuntimeConfig()
@@ -55,16 +55,28 @@ const loadMore = async () => {
   page.value += 1
   //console.log("page.value", page.value)
   pendingMore.value = true
-  const moreShows = await $fetch(
-    `${config.public.BFF_URL}/api/show/${route.params.slug}?page=${page.value}`
-  )
-  pendingMore.value = false
-  episodes.value = [...episodes.value, ...moreShows?.episodes?.data]
-  trackClickEvent(
-    "Event Tracking - load more episodes",
-    "Shows Page",
-    show.value.show.title
-  )
+  try {
+    const moreShows = await $fetch(
+      `${config.public.BFF_URL}/api/show/${route.params.slug}?page=${page.value}`
+    )
+    pendingMore.value = false
+    episodes.value = [...episodes.value, ...moreShows?.episodes?.data]
+    trackClickEvent(
+      "Event Tracking - load more episodes",
+      "Shows Page",
+      show.value.show.title
+    )
+  } catch (error) {
+    const globalToast = useGlobalToast()
+    globalToast.value = {
+      severity: "error",
+      summary:
+        "Sorry. We are having trouble loading more episodes. Please try again later.",
+      life: null,
+      closable: true,
+    }
+    console.error("error = ", error)
+  }
 }
 
 const user = useCurrentUser()

--- a/pages/browse/shows/[slug].vue
+++ b/pages/browse/shows/[slug].vue
@@ -66,7 +66,7 @@ const loadMore = async () => {
       "Shows Page",
       show.value.show.title
     )
-  } catch (error) {
+  } catch (e) {
     const globalToast = useGlobalToast()
     globalToast.value = {
       severity: "error",
@@ -75,7 +75,7 @@ const loadMore = async () => {
       life: null,
       closable: true,
     }
-    console.error("error = ", error)
+    console.error("error = ", e)
   }
 }
 

--- a/pages/live.vue
+++ b/pages/live.vue
@@ -9,6 +9,7 @@ import {
   useAllCurrentStations,
   useIsEpisodePlaying,
   useIsStreamLoading,
+  useGlobalToast,
 } from "~/composables/states"
 
 const config = useRuntimeConfig()
@@ -138,18 +139,30 @@ const clearAllTimeout = () => {
 const fetchSchedule = async () => {
   clearAllTimeout()
   scheduleRef.value = null
-  const schedule = await $fetch(
-    `${config.public.BFF_URL}/api/schedule/${currentStreamStation.value}`,
-    { method: "POST" }
-  )
-  scheduleRef.value = schedule
-  // init setTimeouts to refetch the schedule when the current event starts
+  try {
+    const schedule = await $fetch(
+      `${config.public.BFF_URL}/api/schedule/${currentStreamStation.value}`,
+      { method: "POST" }
+    )
+    scheduleRef.value = schedule
+    // init setTimeouts to refetch the schedule when the current event starts
 
-  if (scheduleRef.value[0]) {
-    // delay plus 2 seconds to make sure the event has ended and the next one has started so when the  next fetch happens, we get the updated schedule displayed
-    const delay = getTimeDifference(scheduleRef.value[0].attributes.end) + 2000
-    //console.log("delay", delay)
-    timeout = setTimeout(fetchSchedule, delay)
+    if (scheduleRef.value[0]) {
+      // delay plus 2 seconds to make sure the event has ended and the next one has started so when the  next fetch happens, we get the updated schedule displayed
+      const delay = getTimeDifference(scheduleRef.value[0].attributes.end) + 2000
+      //console.log("delay", delay)
+      timeout = setTimeout(fetchSchedule, delay)
+    }
+  } catch (error) {
+    const globalToast = useGlobalToast()
+    globalToast.value = {
+      severity: "error",
+      summary:
+        "Sorry. We are having trouble getting the schedule. Please try again later.",
+      life: null,
+      closable: true,
+    }
+    console.error("error = ", error)
   }
 }
 

--- a/pages/staff/[slug].vue
+++ b/pages/staff/[slug].vue
@@ -51,7 +51,7 @@ const loadMore = async () => {
       ...additionalPageData.articles,
     ]
     trackClickEvent("Event Tracking - load more articles", "Shows Page", staffSlug)
-  } catch (error) {
+  } catch (e) {
     const globalToast = useGlobalToast()
     globalToast.value = {
       severity: "error",
@@ -60,7 +60,7 @@ const loadMore = async () => {
       life: null,
       closable: true,
     }
-    console.error("error = ", error)
+    console.error("error = ", e)
   }
 }
 const authorName = `${pagedata.value?.authorData[0]?.firstName} ${pagedata.value?.authorData[0]?.lastName}`

--- a/pages/staff/[slug].vue
+++ b/pages/staff/[slug].vue
@@ -2,6 +2,7 @@
 import VPerson from "@nypublicradio/nypr-design-system-vue3/v2/src/components/VPerson.vue"
 import { trackClickEvent, goToStoryPage } from "~/utilities/helpers"
 import { useIntersectionObserver } from "@vueuse/core"
+import { useGlobalToast } from "~/composables/states"
 //import { trackClickEvent } from '~/utilities/helpers'
 //import { StaffPage } from '../../composables/types/Page'
 //import { ArticlePage } from '~/composables/types/Page'
@@ -40,15 +41,27 @@ let offset = 0
 // load more articles by the author, triggered by the lazy load observer
 const loadMore = async () => {
   pendingMore.value = true
-  const additionalPageData = await $fetch(
-    `${config.public.BFF_URL}/api/staff/wagtail/${staffSlug}?offset=${(offset += 10)}`
-  )
-  pendingMore.value = false
-  newPageData.value.articles = [
-    ...newPageData.value.articles,
-    ...additionalPageData.articles,
-  ]
-  trackClickEvent("Event Tracking - load more articles", "Shows Page", staffSlug)
+  try {
+    const additionalPageData = await $fetch(
+      `${config.public.BFF_URL}/api/staff/wagtail/${staffSlug}?offset=${(offset += 10)}`
+    )
+    pendingMore.value = false
+    newPageData.value.articles = [
+      ...newPageData.value.articles,
+      ...additionalPageData.articles,
+    ]
+    trackClickEvent("Event Tracking - load more articles", "Shows Page", staffSlug)
+  } catch (error) {
+    const globalToast = useGlobalToast()
+    globalToast.value = {
+      severity: "error",
+      summary:
+        "Sorry. We are having trouble loading more articles. Please try again later.",
+      life: null,
+      closable: true,
+    }
+    console.error("error = ", error)
+  }
 }
 const authorName = `${pagedata.value?.authorData[0]?.firstName} ${pagedata.value?.authorData[0]?.lastName}`
 

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -553,7 +553,7 @@ export const deleteFavorite = async (media: object, tableArg = 'favorited') => {
 
 
 // handles saving a favorite or recently played item
-// if a duplicate existingRecord is found, it removed the original and adds the new one
+// if a duplicate existingRecord is found, it removes the original and adds the new one
 export const saveFavorite = async (media: object, typeArg: string, tableArg = "favorited") => {
   const user = useCurrentUser()
   if (user.value) {
@@ -563,8 +563,7 @@ export const saveFavorite = async (media: object, typeArg: string, tableArg = "f
       .from(tableArg)
       .select('*')
       .eq("uid", user.value.id)
-      .eq('slug', media?.slug);
-
+      .eq('slug', media?.meta.slug);
     if (existingError) throw existingError;
     if (existingRecord && existingRecord.length > 0) {
       await deleteFavorite(existingRecord[0], tableArg)


### PR DESCRIPTION
tackled a bunch of backlog loose ends

- no more duplications in history/recently_viewed
- updating the default live stream now updates the render of the live feature on the homepage only if a live stream is NOT playing. It will always update the local storage/ supabase as always
- live page top play button now displays loading indication spinner
- large card 3dot menus now have icons next to Download and Emebed
- removed unused watches and unnecessary deeps in some watches
- added try catches around the $fetch() and live stream calls to fire global toast notification
- google avatar in the settings now shows up again.
- info plist update for legal blurb on how we will use the users data. This will eventually need to be replaced with the real thing.