### PR TITLE
Update Android Fastlane configuration and prod workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,9 @@ workflows:
           requires:
             - test
       - android:
-          name: Android (beta)
+          name: Android (demo)
           context: android
-          FASTLANE_LANE: beta
+          FASTLANE_LANE: internal
           env: demo
           <<: *filter_demo
           requires:
@@ -81,6 +81,14 @@ workflows:
             - xcode
           FASTLANE_LANE: beta
           env: prod
+          <<: *filter_prod
+          requires:
+            - test
+      - android:
+          name: Android (prod)
+          context: android
+          FASTLANE_LANE: gamma
+          env: demo
           <<: *filter_prod
           requires:
             - test

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :android do
     gradle(task: "assemble", build_type: "Release")
   end
 
-  lane :beta do
+  lane :internal do
     # Adjust the `build_type` and `flavor` params as needed to build the right APK for your setup
     gradle(
       task: 'bundle',
@@ -35,6 +35,19 @@ platform :android do
     upload_to_play_store(
       release_status: 'completed',
       track: 'internal',
+      package_name: 'org.wnyc.android'
+    ) # upload to Google Play Store
+  end
+
+  lane :gamma do
+    # Adjust the `build_type` and `flavor` params as needed to build the right APK for your setup
+    gradle(
+      task: 'bundle',
+      build_type: 'Release'
+    )
+    upload_to_play_store(
+      release_status: 'completed',
+      track: 'gamma',
       package_name: 'org.wnyc.android'
     ) # upload to Google Play Store
   end


### PR DESCRIPTION
Update Android Fastlane configuration and prod workflow. On android I will be using the gamma track to send production builds which can then be released to prod from there. These builds will be pointing to the production bff address. 