### PR TITLE
Wcolon/wnyc 251

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypr.ios.WNYC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.nypr.ios.WNYC 1712161736";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.nypr.ios.WNYC";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -920,7 +920,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wnyc.iphone;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.wnyc.iphone 1692304799";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.wnyc.iphone";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/App/App.xcodeproj/xcshareddata/xcschemes/AppAlpha.xcscheme
+++ b/ios/App/App.xcodeproj/xcshareddata/xcschemes/AppAlpha.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/ios/App/App/AppRelease.entitlements
+++ b/ios/App/App/AppRelease.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:native-app.wnyc.org</string>

--- a/server/api/homepagecuration.ts
+++ b/server/api/homepagecuration.ts
@@ -95,7 +95,7 @@ export default defineEventHandler(async (event) => {
 	const homeTemplate = await getHomeTemplate();
 	const nprStories = await getNprStories();
 
-	res.setHeader('Cache-Control', 'maxage=900, stale-while-revalidate');
+	res.setHeader('Cache-Control', 'maxage=120, stale-while-revalidate');
 
 	return {
 		home_template: homeTemplate,

--- a/server/api/homepagelatestnewsupdates.ts
+++ b/server/api/homepagelatestnewsupdates.ts
@@ -110,7 +110,7 @@ export default defineEventHandler(async (event) => {
 		local_newscast = await getLocalNewscast();
 	}
 	const national_newscast = await getNationalNewscast();
-	res.setHeader('Cache-Control', 'maxage=900, stale-while-revalidate');
+	res.setHeader('Cache-Control', 'maxage=120, stale-while-revalidate');
 
 	return {
 		local_newscast,

--- a/server/api/homepagetopstories.ts
+++ b/server/api/homepagetopstories.ts
@@ -87,7 +87,7 @@ export default defineEventHandler(async (event) => {
 	const publisher = await getWNYCTopStories();
 	const topStories = mergeArticles(aviary, publisher);
 
-	res.setHeader('Cache-Control', 'maxage=900, stale-while-revalidate');
+	res.setHeader('Cache-Control', 'maxage=120, stale-while-revalidate');
 
 	return {
 		top_stories: topStories,

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -35,7 +35,7 @@ const getLivestreams = async () => {
  */
 export default defineEventHandler(async (event) => {
     let res = event?.node?.res;
-    res.setHeader('Cache-Control', 'maxage=3600, stale-while-revalidate');
+    res.setHeader('Cache-Control', 'maxage=120, stale-while-revalidate');
     const streams = await getLivestreams();
     return streams
 })


### PR DESCRIPTION
Set the cache-control headers to 2 minute caches on homepage items. 
Update provisioning profile for the project.