### PR TITLE
Update cache control maxage to 300 seconds for NPR

### DIFF
--- a/server/api/homepagecuration.ts
+++ b/server/api/homepagecuration.ts
@@ -95,7 +95,7 @@ export default defineEventHandler(async (event) => {
 	const homeTemplate = await getHomeTemplate();
 	const nprStories = await getNprStories();
 
-	res.setHeader('Cache-Control', 'maxage=120, stale-while-revalidate');
+	res.setHeader('Cache-Control', 'maxage=300, stale-while-revalidate');
 
 	return {
 		home_template: homeTemplate,


### PR DESCRIPTION
Update cache control maxage to 300 seconds for NPR