### PR TITLE
Wcolon/wnyc 262

### DIFF
--- a/server/api/homepagelatestnewsupdates.ts
+++ b/server/api/homepagelatestnewsupdates.ts
@@ -45,6 +45,8 @@ const getNationalNewscast = async () => {
 		};
 		const res = await axios(options);
 		const resData = humps.camelizeKeys(res.data).data;
+		const mp3Res = await axios(resData.attributes.audio);
+		resData.attributes.newsdate = mp3Res.headers.lastModified;
 		resData.attributes.file = resData.attributes.audio;
 		resData.attributes.image = 'https://media.wnyc.org/i/%s/%s/%s/%s/2023/09/npr-news-now.jpeg';
 		resData.attributes.duration = await handleDuration(resData.attributes.estimatedDuration, resData.attributes.audio);

--- a/server/api/homepagelatestnewsupdates.ts
+++ b/server/api/homepagelatestnewsupdates.ts
@@ -46,7 +46,7 @@ const getNationalNewscast = async () => {
 		const res = await axios(options);
 		const resData = humps.camelizeKeys(res.data).data;
 		const mp3Res = await axios(resData.attributes.audio);
-		resData.attributes.newsdate = mp3Res.headers.lastModified;
+		resData.attributes.newsdate = mp3Res.headers['last-modified'];
 		resData.attributes.file = resData.attributes.audio;
 		resData.attributes.image = 'https://media.wnyc.org/i/%s/%s/%s/%s/2023/09/npr-news-now.jpeg';
 		resData.attributes.duration = await handleDuration(resData.attributes.estimatedDuration, resData.attributes.audio);


### PR DESCRIPTION
Implement a fix to the National News updates as they showed up as being 10 years old. The fix I have pulls the 'last-modified' from the headers of the mp3 file. This being done as part of the BFF.