### PR TITLE
expanded player DS update to resolve some andriod issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@jofr/capacitor-media-session": "3.0.3",
         "@nuxt/image": "1.4.0",
         "@nuxtjs/supabase": "1.1.6",
-        "@nypublicradio/nypr-design-system-vue3": "^2.1.40",
+        "@nypublicradio/nypr-design-system-vue3": "^2.1.41",
         "@sentry/integrations": "^7.93.0",
         "@sentry/tracing": "^7.93.0",
         "@sentry/vue": "^7.93.0",
@@ -4154,9 +4154,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "2.1.40",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.1.40/73f438671d2e1cc4be1a54ab934dfa6097c103a9",
-      "integrity": "sha512-YbU2iNiNaBSXqoQ34nSlbLMGXW+5KnzxpZBFcU1/TsLBpr0Eew4nb6/cET7/sJucTvbCqym1uJ6WZAtma8BV1w==",
+      "version": "2.1.41",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/2.1.41/6b9fb0163274429d87fc79ce9af652c77ec0e33c",
+      "integrity": "sha512-Hj/LuGUOEswQ0jWrgvOsN+W+BpJ65YLwTGa6CWtAP3aScxF+z7eCq6VkUaUOYPx0ss2gITetEKD91oeg7s19CA==",
       "dependencies": {
         "@capacitor/browser": "^5.0.6",
         "@nuxt/image": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@jofr/capacitor-media-session": "3.0.3",
     "@nuxt/image": "1.4.0",
     "@nuxtjs/supabase": "1.1.6",
-    "@nypublicradio/nypr-design-system-vue3": "^2.1.40",
+    "@nypublicradio/nypr-design-system-vue3": "^2.1.41",
     "@sentry/integrations": "^7.93.0",
     "@sentry/tracing": "^7.93.0",
     "@sentry/vue": "^7.93.0",


### PR DESCRIPTION
Android fixes being pushed:
when the player is expanded,  a user can scroll to the bottom, close the expanded player, open it again, and the scroll position is where they left off. Now it is back at the top
expanded player hiccup/pausing issues resolved