### PR TITLE
Remove articles with restricted content from npr stories

### DIFF
--- a/server/api/homepagecuration.ts
+++ b/server/api/homepagecuration.ts
@@ -79,11 +79,22 @@ const getNprStories = async () => {
 	try {
 		response = await axios(options);
 		const normalizeArticles = await Promise.all(response.data.resources.map((article) => {
-			return normalizeNprPage(article, componentType);
+			for (const asset of Object.values(article.assets)) {
+				if (asset?.isRestrictedToAuthorizedOrgServiceIds === true) {
+					article.isRestrictedToAuthorizedOrgServiceIds = true;
+					break;
+				}
+			}
+			//remove article if it contains restricted content
+			 if (!article?.isRestrictedToAuthorizedOrgServiceIds) {
+				return normalizeNprPage(article, componentType);
+			}
 		}));
 
+		// Remove null and undefined articles
+		const cleanedArticles = normalizeArticles.filter((article) => article !== undefined && article !== null);
 		// remove articles with no body content or empty body content
-		const filteredArticles = normalizeArticles.filter((article) => article.body !== null && article.body !== '');
+		const filteredArticles = cleanedArticles.filter((article) => article.body !== null && article.body !== '');
 
 		// Sort articles by "updatedDate" if it exists, otherwise by "publicationDate" in reverse cronological order
 		const articles = filteredArticles.sort((a, b) => {

--- a/server/api/homepagecuration.ts
+++ b/server/api/homepagecuration.ts
@@ -86,7 +86,9 @@ const getNprStories = async () => {
 				}
 			}
 			//remove article if it contains restricted content
-			 if (!article?.isRestrictedToAuthorizedOrgServiceIds) {
+			if (article?.isRestrictedToAuthorizedOrgServiceIds) {
+				return null;
+			} else {
 				return normalizeNprPage(article, componentType);
 			}
 		}));


### PR DESCRIPTION
Filter the articles and removes anything that contains the isRestrictedToAuthorizedOrgServiceIds key with the value of true in assets. 