### PR TITLE
Remove bluetooth-central background mode from Info.plist

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -53,7 +53,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>bluetooth-central</string>
 		<string>fetch</string>
 		<string>processing</string>
 		<string>remote-notification</string>

--- a/ios/App/AppAlpha-Info.plist
+++ b/ios/App/AppAlpha-Info.plist
@@ -55,7 +55,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>bluetooth-central</string>
 		<string>fetch</string>
 		<string>processing</string>
 		<string>remote-notification</string>


### PR DESCRIPTION
Remove bluetooth-central background mode from Info.plist
[WNYC-297](https://nypublicradio-digital.atlassian.net/browse/WNYC-297)

[WNYC-297]: https://nypublicradio-digital.atlassian.net/browse/WNYC-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ