### PR TITLE
chore: Add get_release_version step to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ jobs:
     steps:
       - checkout
       - setup_mobile_env
+      - get_release_version
       - ruby/install-deps:
           app-dir: ios/App
           key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "ios/App/Gemfile.lock" }}
@@ -210,6 +211,7 @@ jobs:
     steps:
       - checkout
       - setup_mobile_env
+      - get_release_version
       - ruby/install-deps:
           app-dir: android
           key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "android/Gemfile.lock" }}
@@ -250,6 +252,7 @@ jobs:
     steps:
       - checkout
       - setup_npmrc
+      - get_release_version
       - setup_remote_docker         
       - run:
           name: Deploy
@@ -286,6 +289,12 @@ commands:
           command: |
             echo "@nypublicradio:registry=https://npm.pkg.github.com" > .npmrc
             echo "//npm.pkg.github.com/:_authToken=$PAT" >> .npmrc
+  get_release_version:
+    steps:
+      - run:
+          name: Get tag release version
+          command: |
+            export APP_VERSION=$(git describe --abbrev=0 --tags | sed -E 's/(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
   setup_mobile_env:
     steps:
       - run:


### PR DESCRIPTION
Gets the latest tag release and uses that as the app version number. It just sets the env var. The rest is handled in a branch that Bono has a PR for. 