### PR TITLE
Sentry Replay allow text and images

### DIFF
--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/vue'
-import { HttpClient, httpClientIntegration } from '@sentry/integrations'
+import { HttpClient } from '@sentry/integrations'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const { vueApp } = nuxtApp
@@ -14,11 +14,11 @@ export default defineNuxtPlugin((nuxtApp) => {
         routingInstrumentation: Sentry.vueRouterInstrumentation(nuxtApp.$router),
         tracePropagationTargets: ['cms.demo.nypr.digital', 'api.demo.nypr.digital', 'cms.prod.nypr.digital', 'api.prod.nypr.digital', 'demo.native-app.wnyc.org', 'api.wnyc.org'],
       }),
-      new replayIntegration({
+      new HttpClient(),
+      new Sentry.Replay({
         maskAllText: false,
         blockAllMedia: false
       }),
-      new httpClientIntegration(),
     ],
     tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.1 : 1.0,
     replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.0005 : 1.0,

--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/vue'
-import { HttpClient } from '@sentry/integrations'
+import { HttpClient, httpClientIntegration } from '@sentry/integrations'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const { vueApp } = nuxtApp
@@ -14,13 +14,17 @@ export default defineNuxtPlugin((nuxtApp) => {
         routingInstrumentation: Sentry.vueRouterInstrumentation(nuxtApp.$router),
         tracePropagationTargets: ['cms.demo.nypr.digital', 'api.demo.nypr.digital', 'cms.prod.nypr.digital', 'api.prod.nypr.digital', 'demo.native-app.wnyc.org', 'api.wnyc.org'],
       }),
-      new HttpClient(),
-      new Sentry.Replay(),
+      new replayIntegration({
+        maskAllText: false,
+        blockAllMedia: false
+      }),
+      new httpClientIntegration(),
     ],
-    tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.5 : 1.0,
+    tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.1 : 1.0,
     replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.0005 : 1.0,
     replaysOnErrorSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.001 : 1.0,
     allowUrls: [
+      'https://native-app.wnyc.org',
       'https://demo.native-app.wnyc.org',
       'http://local.dev.nypr.digital:3000',
       'capacitor://localhost',


### PR DESCRIPTION
Update the Sentry Replay configuration to allow images and text to be displayed in the replay to help in the troubleshooting process.