### PR TITLE
chore: Update app version to use environment variables

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,9 +5,9 @@ def keyStorePropertiesFile = rootProject.file("keystore.properties")
 def keyStoreProperties = new Properties()
 keyStoreProperties.load(new FileInputStream(keyStorePropertiesFile))
 
-ext.versionMajor = 4
-ext.versionMinor = 0
-ext.versionPatch = 2
+ext.versionMajor = System.getenv("APP_VERSION_MAJOR") ?: 4
+ext.versionMinor = System.getenv("APP_VERSION_MINOR") ?: 0
+ext.versionPatch = System.getenv("APP_VERSION_PATCH") ?: 2
 ext.versionClassifier = null
 ext.isSnapShot = false
 ext.minSdkVersion = 22

--- a/ios/App/fastlane/Fastfile
+++ b/ios/App/fastlane/Fastfile
@@ -102,7 +102,9 @@ platform :ios do
     increment_build_number(
       build_number: "$CIRCLE_BUILD_NUM"
     )
-    increment_version_number
+    increment_version_number(
+      version_number: "$APP_VERSION"
+    )
     build_app(
       workspace: "App.xcworkspace",
       scheme: "App",

--- a/scripts/rename_env_vars.sh
+++ b/scripts/rename_env_vars.sh
@@ -17,5 +17,8 @@ done < <(printenv | grep "^${env_var_prefix}")
 
 export APP_VERSION=$(git describe --abbrev=0 --tags | sed -E 's/(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 echo "APP_VERSION=${APP_VERSION}" >> local-env
+echo "APP_VERSION_MAJOR=$(echo ${APP_VERSION} | cut -d. -f1 | cut -c2-)" >> local-env
+echo "APP_VERSION_MINOR=$(echo ${APP_VERSION} | cut -d. -f2)" >> local-env
+echo "APP_VERSION_PATCH=$(echo ${APP_VERSION} | cut -d. -f3)" >> local-env
 cat local-env | sed 's/\(^[^=]*\)=\(.*\)/export \1="\2"/' >> ~/.bash_profile
 source ~/.bash_profile


### PR DESCRIPTION
The APP_VERSION comes from the tag. Going forward tags should start from 4.2.0-pre1 and once approved the next tag must increment the patch. 