### PR TITLE
chore: Update local-env script to handle "demo" version

### DIFF
--- a/scripts/rename_env_vars.sh
+++ b/scripts/rename_env_vars.sh
@@ -16,10 +16,18 @@ while IFS= read -r env_var; do
 done < <(printenv | grep "^${env_var_prefix}")
 
 export APP_VERSION=$(git describe --abbrev=0 --tags | sed -E 's/(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-echo "APP_VERSION=${APP_VERSION}" >> local-env
-echo "APP_VERSION_MAJOR=$(echo ${APP_VERSION} | cut -d. -f1 | cut -c2-)" >> local-env
-echo "APP_VERSION_MINOR=$(echo ${APP_VERSION} | cut -d. -f2)" >> local-env
-echo "APP_VERSION_PATCH=$(echo ${APP_VERSION} | cut -d. -f3)" >> local-env
-echo "APP_SHORT_VERSION=$(echo ${APP_VERSION} | cut -d. -f1 | cut -c2-).$(echo ${APP_VERSION} | cut -d. -f2)" >> local-env
+
+if [ $APP_VERSION == "demo" ]; then
+    echo "APP_VERSION=4.1.0" >> local-env
+    echo "APP_VERSION_MAJOR=4" >> local-env
+    echo "APP_VERSION_MINOR=1" >> local-env
+    echo "APP_VERSION_PATCH=0" >> local-env
+else
+    echo "APP_VERSION=${APP_VERSION}" >> local-env
+    echo "APP_VERSION_MAJOR=$(echo ${APP_VERSION} | cut -d. -f1 | cut -c2-)" >> local-env
+    echo "APP_VERSION_MINOR=$(echo ${APP_VERSION} | cut -d. -f2)" >> local-env
+    echo "APP_VERSION_PATCH=$(echo ${APP_VERSION} | cut -d. -f3)" >> local-env
+    echo "APP_SHORT_VERSION=$(echo ${APP_VERSION} | cut -d. -f1 | cut -c2-).$(echo ${APP_VERSION} | cut -d. -f2)" >> local-env
+fi
 cat local-env | sed 's/\(^[^=]*\)=\(.*\)/export \1="\2"/' >> ~/.bash_profile
 source ~/.bash_profile


### PR DESCRIPTION
Demo builds were failing because the git describe tags is only returning the demo tag while you have the demo tag checked out. Had to set the env vars to a static version. 