### PR TITLE
update macOS executor to use Xcode 16.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ executors:
       JOBS: 2
   macosg2:
     macos:
-      xcode: "15.2.0"
+      xcode: "16.2.0"
     resource_class: macos.m1.large.gen1
     environment:
       JOBS: 2


### PR DESCRIPTION
Update macOS executor to use Xcode 16.2.0 (latest available on circleci)