### PR TITLE
Fixes to the cancellation endpoint

### DIFF
--- a/server/api/donation/cancel.post.ts
+++ b/server/api/donation/cancel.post.ts
@@ -3,9 +3,6 @@ import { createError, defineEventHandler, readBody } from 'h3';
 import { requireAuth } from '../../utils/jwt';
 import { rateLimit } from '../../utils/rateLimiter';
 
-// Runtime config for environment variables
-const config = useRuntimeConfig();
-
 // Response type definition
 interface DonationCancelResponse {
     status: string;
@@ -59,8 +56,8 @@ const validateCancelRequest = (body: any): { did: number; reason: string } => {
  */
 const cancelDonationWithSpringboard = async (donationId: number, reason: string): Promise<DonationCancelResponse> => {
     try {
-        const springboardUrl = config.SPRINGBOARD_URL;
-        const springboardKey = config.SPRINGBOARD_KEY;
+        const springboardUrl = process.env.SPRINGBOARD_URL;
+        const springboardKey = process.env.SPRINGBOARD_KEY;
 
         if (!springboardUrl || !springboardKey) {
             throw createError({
@@ -71,18 +68,14 @@ const cancelDonationWithSpringboard = async (donationId: number, reason: string)
         }
 
         const apiUrl = `${springboardUrl}/springboard-api/springboard-donation/cancel`;
-
-        // Prepare the request payload
-        const requestBody = {
-            did: donationId,
-            reason
-        };
-
-        const response = await axios.post(apiUrl, requestBody, {
+        const response = await axios.get(apiUrl, {
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${springboardKey}`,
+                'api-key': springboardKey,
                 'Accept': 'application/json'
+            },
+            params: {
+                did: donationId,
+                reason: encodeURIComponent(reason)
             }
         });
 


### PR DESCRIPTION
This pull request updates the donation cancellation endpoint to improve environment variable usage and align the API call with the expected request format for the Springboard service. The most important changes are grouped below:

Environment variable handling:

* Replaced usage of `useRuntimeConfig()` with direct access to environment variables via `process.env` for `SPRINGBOARD_URL` and `SPRINGBOARD_KEY`. [[1]](diffhunk://#diff-df66cab5a0c31d6f243c116440687734b682b3325749530da3a23583ce2f47fdL6-L8) [[2]](diffhunk://#diff-df66cab5a0c31d6f243c116440687734b682b3325749530da3a23583ce2f47fdL62-R60)

Springboard API request changes:

* Changed the Springboard cancellation API call from a `POST` request with a JSON body to a `GET` request with parameters (`did` and `reason`) passed in the query string, and updated the request headers to use `api-key` instead of `Authorization`.