### PR TITLE
fix: change donation update API request method from GET to POST

### DIFF
--- a/server/api/donation/update.post.ts
+++ b/server/api/donation/update.post.ts
@@ -65,7 +65,7 @@ const updateDonationWithSpringboard = async (donationId: number, newAmount: numb
 
     try {
         const apiUrl = `${springboardUrl}/springboard-api/springboard-donation/update-amount`;
-        const response = await axios.get(apiUrl, {
+        const response = await axios.post(apiUrl, {
             headers: {
                 'api-key': springboardKey,
                 'Accept': 'application/json'


### PR DESCRIPTION
The springboard endpoint is expecting a post even though it's also expecting the data to be passed as query params. 