### PR TITLE
Update mock data usage condition to apply only in local development

### DIFF
--- a/server/api/v2/schedule/[stationslug].get.ts
+++ b/server/api/v2/schedule/[stationslug].get.ts
@@ -51,11 +51,11 @@ const shouldUseMockData = (): boolean => {
         return true
     }
     
-    // Auto-detect: use mock data in development or when S3 bucket is not configured
-    const isDevEnvironment = process.env.NODE_ENV === 'development' || process.env.ENV === 'demo'
+    // Auto-detect: use mock data only in local development when S3 bucket is not configured
+    const isLocalDevelopment = process.env.NODE_ENV === 'development'
     const hasS3Config = Boolean(process.env.S3_SCHEDULE_BUCKET)
     
-    return isDevEnvironment && !hasS3Config
+    return isLocalDevelopment && !hasS3Config
 }
 
 // Function to read JSON data from local file system


### PR DESCRIPTION
This is necessary in order for demo to be able to pull from s3 and not a local copy for testing. 