### PR TITLE
Incorporate processing transactions into BFF user record response

### DIFF
--- a/server/api/donation/cancel.post.ts
+++ b/server/api/donation/cancel.post.ts
@@ -110,7 +110,7 @@ const cancelDonationWithSpringboard = async (donationId: number, reason: string,
             springboard_id: donationId,
             salesforce_id: salesforceId ?? null,
             type: 'donation_cancel',
-            status: 'pending',
+            status: 'Pending',
 
         });
 

--- a/server/api/donation/update.post.ts
+++ b/server/api/donation/update.post.ts
@@ -85,7 +85,7 @@ const updateDonationWithSpringboard = async (donationId: number, newAmount: numb
             springboard_id: donationId,
             salesforce_id: salesforceId ?? null,
             type: 'donation_update',
-            status: 'pending',
+            status: 'Pending',
             new_amount: newAmount,
         });
 

--- a/server/api/profile.post.ts
+++ b/server/api/profile.post.ts
@@ -2,6 +2,11 @@ import salesforce from '../utils/salesforce';
 import { createError, defineEventHandler, readBody } from 'h3';
 import { requireAuth } from '../utils/jwt';
 import { rateLimit } from '../utils/rateLimiter';
+import { supabaseClient } from '~/server/utils/supabaseClient';
+import { NyprDb } from '~/server/utils/nyprdb';
+
+const supabase = supabaseClient();
+const nyprDb = new NyprDb(supabase);
 
 // Response type definitions
 interface RecurringDonation {
@@ -10,6 +15,7 @@ interface RecurringDonation {
     amount: number | null;
     nextChargeDate: string | null;
     membershipStartDate: string | null;
+    status?: string | null;
 }
 
 interface ProfileResponse {
@@ -142,8 +148,40 @@ const getActiveRecurringDonations = async (contact: any): Promise<any[]> => {
                 'cfg_Digital_Membership_Program_Name__c'
             ]
         );
-
-        return recurringDonations || [];
+        
+        const transactions = await nyprDb.getTransactionsBySalesforceId(contact.Id);
+        
+        // Create maps of springboard_id to status and amount for quick lookup
+        const statusMap = new Map<number, string>();
+        const amountMap = new Map<number, number>();
+        if (transactions && transactions.length > 0) {
+            transactions.forEach(transaction => {
+                if (transaction.springboard_id) {
+                    statusMap.set(transaction.springboard_id, transaction.status || 'Completed');
+                    // If type is donation_update and new_amount exists, store it
+                    if (transaction.type === 'donation_update' && transaction.new_amount != null) {
+                        amountMap.set(transaction.springboard_id, transaction.new_amount);
+                    }
+                }
+            });
+        }
+        
+        // Attach status and updated amount to each recurring donation
+        const donationsWithStatus = (recurringDonations || []).map(donation => {
+            const springboardId = Number(donation.Master_Donation_ID__c);
+            const updatedAmount = donation.Master_Donation_ID__c ? amountMap.get(springboardId) : undefined;
+            
+            return {
+                ...donation,
+                // Use updated amount if available, otherwise use original amount
+                npe03__Amount__c: updatedAmount !== undefined ? updatedAmount : donation.npe03__Amount__c,
+                status: donation.Master_Donation_ID__c 
+                    ? statusMap.get(springboardId) || 'Completed'
+                    : 'Complete'
+            };
+        });
+        
+        return donationsWithStatus;
     } catch (error: any) {
         // Enhanced error handling with categorization
         const statusCode = error.name === 'SalesforceError' && error.type === 'authentication' ? 401 :
@@ -169,7 +207,8 @@ const formatRecurringDonations = (donations: any[]): RecurringDonation[] => {
         brand: donation.nypr_GAU_Property_Name_Current__c,
         amount: donation.npe03__Amount__c,
         nextChargeDate: donation.npe03__Next_Payment_Date__c,
-        membershipStartDate: donation.npe03__Date_Established__c
+        membershipStartDate: donation.npe03__Date_Established__c,
+        status: donation.status
     }));
 };
 

--- a/server/utils/nyprdb.ts
+++ b/server/utils/nyprdb.ts
@@ -24,6 +24,7 @@ interface Transaction {
     readonly springboard_id?: number | null;
     readonly type?: string | null;
     readonly status?: string | null;
+    readonly new_amount?: number | null;
     readonly created_at?: string;
     readonly updated_at?: string | null;
 }
@@ -94,6 +95,24 @@ export class NyprDb {
             return null
         }
         return data?.slug ?? null
+    }
+
+    /**
+     * Get transactions by salesforce_id 
+     */
+    async getTransactionsBySalesforceId(salesforce_id: string): Promise<Transaction[] | null> {
+        const { data, error } = await this.supabase
+            .from('transactions')
+            .select('*')
+            .eq('salesforce_id', salesforce_id)
+            .eq('status', 'Pending');
+
+        if (error) {
+            console.error('Error fetching transaction by salesforce_id:', error);
+            return null;
+        }
+
+        return data;
     }
 
     /**


### PR DESCRIPTION
Incorporate processing transactions into BFF user record response. The response will now contain a status in each of the recurring donation. This is coming from the transactions table which stores updates and cancels and puts them in a status of pending. These will eventually be reconciled by a job that will run and update the status field from Pending to Completed once the transaction has been processed. The reason for this is that Salesforce to Springboard sync is not instantaneous. The transactions table helps bridge that gap. 