### PR TITLE
Serve pre-Simplecast stories from Publisher via the BFF

### DIFF
--- a/pages/story/[slug].vue
+++ b/pages/story/[slug].vue
@@ -7,12 +7,12 @@ const route = useRoute()
 const config = useRuntimeConfig()
 
 const isWagtail = route.query.src === cmsSources.WAGTAIL
-const storySource = isWagtail ? "Gothamist" : "WNYC"
+const storySource = "WNYC"
 
 const breadcrumbs = computed(() => [{ label: "Home", route: "/home" }])
 
 const { data: storyData, status, error } = useFetch(
-  `${config.public.BFF_URL}/api/story/${route.query.src}/${route.params.slug}`,
+  `${config.public.BFF_URL}/api/story/publisher/${route.params.slug}`,
   {
     onResponse({ response }) {
       const res = response._data

--- a/pages/story/[slug].vue
+++ b/pages/story/[slug].vue
@@ -6,13 +6,12 @@ const { topStories } = useTopStories()
 const route = useRoute()
 const config = useRuntimeConfig()
 
-const isWagtail = route.query.src === cmsSources.WAGTAIL
 const storySource = "WNYC"
 
 const breadcrumbs = computed(() => [{ label: "Home", route: "/home" }])
 
 const { data: storyData, status, error } = useFetch(
-  `${config.public.BFF_URL}/api/story/publisher/${route.params.slug}`,
+  `${config.public.BFF_URL}/api/story/${cmsSources.PUBLISHER}/${route.params.slug}`,
   {
     onResponse({ response }) {
       const res = response._data

--- a/server/api/story/[cmsSource]/[storyId].ts
+++ b/server/api/story/[cmsSource]/[storyId].ts
@@ -20,11 +20,17 @@ const getWagtailStoryData = async (id: string) => {
     return null
 };
 
-const getPublisherStoryData = async (id: string) => {
+const getPublisherStoryData = async (idOrSlug: string) => {
     try {
+        // Determine if the identifier is numeric (ID) or a slug
+        const isNumericId = /^\d+$/.test(idOrSlug);
+        const endpoint = isNumericId 
+            ? `v3/story-pk/${idOrSlug}/`
+            : `v3/story/${idOrSlug}/`;
+        
         const option = {
             method: 'GET',
-            url: `${config.public.PUBLISHER_BASE_API}v3/story-pk/${id}/`,
+            url: `${config.public.PUBLISHER_BASE_API}${endpoint}`,
         };
         const res = await axios(option);
         return normalizePublisherPage(humps.camelizeKeys(res.data).data);


### PR DESCRIPTION
Updated the server api to detect if it's an id or a slug to route the backend request correctly. set the /story/slug to default to publisher as the new content will live under a different path. 