### PR TITLE
Refactor getWagtailPageData to improve error handling

### DIFF
--- a/server/api/pages/[cmsSource]/[pageSlug].ts
+++ b/server/api/pages/[cmsSource]/[pageSlug].ts
@@ -28,19 +28,28 @@ const getWagtailPageData = async (pageSlug: string) => {
             'X-CMS-Site': config.cmsSite || 'demo.wnyc.org:443'
         }
     };
-    const res = await axios(options);
-    const resData = humps.camelizeKeys(res.data);
+    
+    try {
+        const res = await axios(options);
+        const resData = humps.camelizeKeys(res.data);
+        
+        // Add cmsSource to the data so normalizeArticlePage knows which normalizer to use
+        resData.cmsSource = cmsSources.WAGTAIL;
 
-    // Transform curated content if it exists
-    if (resData.curatedContent && Array.isArray(resData.curatedContent)) {
-        const transformedCuratedContent = await transformCuratedContent(resData.curatedContent);
-        return {
-            ...resData,
-            curatedContent: transformedCuratedContent
-        };
+        // Transform curated content if it exists
+        if (resData.curatedContent && Array.isArray(resData.curatedContent)) {
+            const transformedCuratedContent = await transformCuratedContent(resData.curatedContent);
+            return {
+                ...resData,
+                curatedContent: transformedCuratedContent
+            };
+        }
+        
+        return await normalizeArticlePage(resData);
+    } catch (error) {
+        console.error('Error in getWagtailPageData:', error);
+        throw error;
     }
-
-    return await normalizeArticlePage(resData);
 };
 
 // get page data from the proper CMS


### PR DESCRIPTION
Refactor getWagtailPageData to improve error handling. Prior to this we were getting back an empty response. Added a try catch block and resolved the issue I was having with a wagtail story. http://local.dev.nypr.digital:3000/api/pages/wagtail/151445