### PR TITLE
Update macOS executor resource class to m4pro.large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ executors:
       JOBS: 2
   macosg2:
     macos:
-      xcode: "16.2.0"
-    resource_class: m4pro.large
+      xcode: "26.2.0"
+    resource_class: m4pro.medium
     environment:
       JOBS: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,6 @@ executors:
   macosg2:
     macos:
       xcode: "16.2.0"
-    resource_class: macos.m1.large.gen1
+    resource_class: m4pro.large
     environment:
       JOBS: 2


### PR DESCRIPTION
Update macOS executor resource class to m4pro.large as the m1 and m2 classes are being decommisioned.