### PR TITLE
Refactor NprAsset interface to use NprProfile and add id property to NprDocument

### DIFF
--- a/components/EpisodeTemplate.vue
+++ b/components/EpisodeTemplate.vue
@@ -382,7 +382,7 @@ const getDotMenuItems = (bucketItem) => {
               }}</template>
               <template #right>
                 <span class="nobreak inline-flex gap-1"
-                  >{{ getDate(props.episodeData, "LLL d, yyyy") }}
+                  >{{ getDate(props.episodeData, "LLL d") }}
                 </span>
               </template>
             </PipeData>

--- a/components/LiveFeature.vue
+++ b/components/LiveFeature.vue
@@ -13,6 +13,7 @@ import {
   togglePlayEpisode,
   initializeStationList,
   getOrg,
+  formatTime,
 } from "~/utilities/helpers"
 import useLiveStream, {
   updateLiveStream,
@@ -116,8 +117,8 @@ const onUpdateStation = (station) => {
                   "
                   class="font-bold"
                 >
-                  {{ currentEpisodeHolder.timeStart }} -
-                  {{ currentEpisodeHolder.timeEnd }}
+                  {{ formatTime(currentEpisodeHolder.timeStart, 'h:mm a') }} -
+                  {{ formatTime(currentEpisodeHolder.timeEnd, 'h:mm a') }}
                 </p>
               </div>
             </div>

--- a/components/StreamSwitcher.vue
+++ b/components/StreamSwitcher.vue
@@ -7,7 +7,7 @@ import {
   useIsEpisodePlaying,
 } from '~/composables/states'
 import { updateLiveStream } from '~/composables/data/liveStream'
-import { trackClickEvent } from '~/utilities/helpers'
+import { trackClickEvent, formatTime } from '~/utilities/helpers'
 
 const currentStreamStation = useCurrentStreamStation()
 const currentEpisode = useCurrentEpisode()
@@ -23,6 +23,8 @@ const initializeSwitcher = (val) => {
   const tempMenuData = []
 
   val.forEach((station) => {
+    const formattedStartTime = station.timeStart ? formatTime(station.timeStart, 'h:mm a') : ''
+    const formattedEndTime = station.timeEnd ? formatTime(station.timeEnd, 'h:mm a') : ''
     tempMenuData.push({
       label: station.title,
       name: station.title,
@@ -30,7 +32,7 @@ const initializeSwitcher = (val) => {
       code: station.title,
       slug: station.slug,
       image: station.image,
-      times: `${station.timeStart} - ${station.timeEnd}`,
+      times: formattedStartTime && formattedEndTime ? `${formattedStartTime} - ${formattedEndTime}` : '',
     })
   })
 

--- a/composables/data/liveStream.ts
+++ b/composables/data/liveStream.ts
@@ -15,7 +15,7 @@ import { clearTimeout, setTimeout } from "worker-timers"
 // Get a list of article pages using the Aviary /pages api
 export async function updateLiveStream (slug: string, save = true) {
   const config = useRuntimeConfig()
-  //BFF
+  //BFF - Uses Schedule API internally
   try {
     const fetchData = await $fetch(`${config.public.BFF_URL}/api/whatson/${slug}`)
     const currentEpisodeHolder = useCurrentEpisodeHolder()
@@ -28,7 +28,7 @@ export async function updateLiveStream (slug: string, save = true) {
     globalToast.value = {
       severity: "error",
       summary:
-        "Sorry. We are having trouble with the live stream. Please try again later.",
+        "Sorry. We are having trouble loading the schedule. Please try again later.",
       life: null,
       closable: true,
     }
@@ -83,7 +83,7 @@ export async function updateAllLiveStreams (init = true) {
     globalToast.value = {
       severity: "error",
       summary:
-        "Sorry. We are having trouble with the live stream. Please try again later.",
+        "Sorry. We are having trouble loading the schedule. Please try again later.",
       life: 8000,
       closable: true,
     }
@@ -428,6 +428,25 @@ export default function useLiveStream () {
         switchStation(targetStation)
         if (autoplay) togglePlayHere()
       }, 100)
+    } else {
+      // Log error when station is not found
+      console.error(`Station with slug "${querySlug}" not found in available stations.`)
+      
+      // Show user-friendly error message
+      const globalToast = useGlobalToast()
+      globalToast.value = {
+        severity: "warn",
+        summary: `Station "${querySlug}" is not available. Loading default station.`,
+        life: 5000,
+        closable: true,
+      }
+      
+      // Fallback to default station (first station or current episode holder)
+      if (currentEpisodeHolder.value) {
+        switchStation(currentEpisodeHolder.value, false)
+      } else if (allCurrentStations.value.length > 0) {
+        switchStation(allCurrentStations.value[0], false)
+      }
     }
   }
   return {

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -227,8 +227,12 @@ const getScheduleFromS3 = async (bucketName: string, key: string) => {
         const jsonData = JSON.parse(bodyString)
 
         return humps.camelizeKeys(jsonData)
-    } catch (error) {
-        console.error('Error reading from S3:', error)
+    } catch (error: any) {
+        // Check if it's a "key not found" error
+        if (error.name === 'NoSuchKey' || error.Code === 'NoSuchKey') {
+            throw error
+        }
+        console.error('Error reading from S3:', error.message)
         throw error
     }
 }
@@ -481,7 +485,25 @@ export default defineEventHandler(async (event) => {
         } else {
             const bucketName = process.env.S3_SCHEDULE_BUCKET as string || 'webstream-metadata-demo'
             const key = `schedule-${slug}.json`
-            scheduleData = await getScheduleFromS3(bucketName, key)
+            try {
+                scheduleData = await getScheduleFromS3(bucketName, key)
+            } catch (s3Error: any) {
+                // If S3 key doesn't exist, try to fall back to local mock file
+                if (s3Error.name === 'NoSuchKey' || s3Error.Code === 'NoSuchKey') {
+                    try {
+                        scheduleData = await getScheduleFromLocalFile(slug)
+                    } catch (mockError) {
+                        console.error(`No schedule data available for ${slug} (neither S3 nor mock)`)
+                        throw createError({
+                            statusCode: 404,
+                            statusMessage: `Schedule data not available for station: ${slug}`,
+                        })
+                    }
+                } else {
+                    // Some other S3 error, rethrow it
+                    throw s3Error
+                }
+            }
         }
         
         // Apply filtering based on mode

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -437,6 +437,114 @@ const filterByDateRange = (scheduleData: any, startDate: string, endDate: string
     }
 }
 
+// Helper function to encapsulate main schedule logic
+const handleScheduleRequest = async (
+    slug: string,
+    filterMode: string,
+    startDate: string | undefined,
+    endDate: string | undefined,
+    res: any,
+    clientEtag: string | undefined
+) => {
+    // Generate cache key based on slug and filter parameters
+    const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}`
+    const cachedEntry = scheduleCache.get(cacheKey)
+    const now = Date.now()
+
+    // If cache is valid and client has current version, return 304
+    if (cachedEntry && (now - cachedEntry.timestamp) < CACHE_TTL) {
+        if (clientEtag === cachedEntry.etag) {
+            res.statusCode = 304
+            res.setHeader('ETag', cachedEntry.etag)
+            res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+            return null
+        }
+        res.setHeader('ETag', cachedEntry.etag)
+        res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+        return cachedEntry.data
+    }
+
+    // Fetch schedule data from S3 or local mock
+    let scheduleData
+    if (shouldUseMockData()) {
+        scheduleData = await getScheduleFromLocalFile(slug)
+    } else {
+        const bucketName = process.env.S3_SCHEDULE_BUCKET as string || 'webstream-metadata-demo'
+        const key = `schedule-${slug}.json`
+        try {
+            scheduleData = await getScheduleFromS3(bucketName, key)
+        } catch (s3Error: any) {
+            if (s3Error.name === 'NoSuchKey' || s3Error.Code === 'NoSuchKey') {
+                try {
+                    scheduleData = await getScheduleFromLocalFile(slug)
+                } catch (mockError) {
+                    console.error(`No schedule data available for ${slug} (neither S3 nor mock)`)
+                    throw createError({
+                        statusCode: 404,
+                        statusMessage: `Schedule data not available for station: ${slug}`,
+                    })
+                }
+            } else {
+                throw s3Error
+            }
+        }
+    }
+
+    // Filtering logic extracted to helper
+    const getFilteredData = () => {
+        switch (filterMode) {
+            case 'next24hours':
+                return filterNext24Hours(scheduleData)
+            case 'specificDate':
+                if (!startDate) {
+                    throw createError({
+                        statusCode: 400,
+                        statusMessage: 'startDate is required for specificDate mode',
+                    })
+                }
+                validateDateRange(scheduleData, startDate)
+                let filtered = filterByDate(scheduleData, startDate)
+                if (isToday(startDate)) {
+                    filtered = removePastEpisodes(filtered)
+                }
+                return filtered
+            case 'dateRange':
+                if (!startDate || !endDate) {
+                    throw createError({
+                        statusCode: 400,
+                        statusMessage: 'startDate and endDate are required for dateRange mode',
+                    })
+                }
+                validateDateRange(scheduleData, startDate, endDate)
+                let filteredRange = filterByDateRange(scheduleData, startDate, endDate)
+                if (includesCurrentDate(startDate, endDate)) {
+                    filteredRange = removePastEpisodes(filteredRange)
+                }
+                return filteredRange
+            case 'all':
+            default:
+                return removePastEpisodes(scheduleData)
+        }
+    }
+
+    const filteredData = getFilteredData()
+    const rewrittenData = rewriteAssetUrls(filteredData)
+    const transformedData = normalizeSchedule(rewrittenData)
+    const dataString = JSON.stringify(transformedData)
+    const etag = `"${createHash('md5').update(dataString).digest('hex')}"`
+
+    scheduleCache.set(cacheKey, {
+        data: transformedData,
+        etag,
+        timestamp: now
+    })
+
+    res.setHeader('ETag', etag)
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+
+    return transformedData
+}
+
 export default defineEventHandler(async (event) => {
     const slug = event?.context?.params?.stationslug as string
     const res = event?.node?.res
@@ -453,133 +561,10 @@ export default defineEventHandler(async (event) => {
     }
 
     try {
-        // Generate cache key based on slug and filter parameters
-        const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}`
-        
-        // Check in-memory cache
-        const cachedEntry = scheduleCache.get(cacheKey)
-        const now = Date.now()
-        
-        // Check if client has current version via ETag
         const clientEtag = event.node.req.headers['if-none-match']
-        
-        // If cache is valid and client has current version, return 304
-        if (cachedEntry && (now - cachedEntry.timestamp) < CACHE_TTL) {
-            if (clientEtag === cachedEntry.etag) {
-                event.node.res.statusCode = 304
-                res.setHeader('ETag', cachedEntry.etag)
-                res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
-                return null
-            }
-            // Cache is valid but client doesn't have current version, return cached data
-            res.setHeader('ETag', cachedEntry.etag)
-            res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
-            return cachedEntry.data
-        }
-
-        
-        // Fetch schedule data from S3 or local mock
-        let scheduleData
-        if (shouldUseMockData()) {
-            scheduleData = await getScheduleFromLocalFile(slug)
-        } else {
-            const bucketName = process.env.S3_SCHEDULE_BUCKET as string || 'webstream-metadata-demo'
-            const key = `schedule-${slug}.json`
-            try {
-                scheduleData = await getScheduleFromS3(bucketName, key)
-            } catch (s3Error: any) {
-                // If S3 key doesn't exist, try to fall back to local mock file
-                if (s3Error.name === 'NoSuchKey' || s3Error.Code === 'NoSuchKey') {
-                    try {
-                        scheduleData = await getScheduleFromLocalFile(slug)
-                    } catch (mockError) {
-                        console.error(`No schedule data available for ${slug} (neither S3 nor mock)`)
-                        throw createError({
-                            statusCode: 404,
-                            statusMessage: `Schedule data not available for station: ${slug}`,
-                        })
-                    }
-                } else {
-                    // Some other S3 error, rethrow it
-                    throw s3Error
-                }
-            }
-        }
-        
-        // Apply filtering based on mode
-        let filteredData
-        switch (filterMode) {
-            case 'next24hours':
-                filteredData = filterNext24Hours(scheduleData)
-                break
-            
-            case 'specificDate':
-                if (!startDate) {
-                    throw createError({
-                        statusCode: 400,
-                        statusMessage: 'startDate is required for specificDate mode',
-                    })
-                }
-                // Validate that the requested date is within available data range
-                validateDateRange(scheduleData, startDate)
-                filteredData = filterByDate(scheduleData, startDate)
-                // If the requested date is today, remove past episodes
-                if (isToday(startDate)) {
-                    filteredData = removePastEpisodes(filteredData)
-                }
-                break
-            
-            case 'dateRange':
-                if (!startDate || !endDate) {
-                    throw createError({
-                        statusCode: 400,
-                        statusMessage: 'startDate and endDate are required for dateRange mode',
-                    })
-                }
-                // Validate that the requested date range is within available data range
-                validateDateRange(scheduleData, startDate, endDate)
-                filteredData = filterByDateRange(scheduleData, startDate, endDate)
-                // If the date range includes today, remove past episodes
-                if (includesCurrentDate(startDate, endDate)) {
-                    filteredData = removePastEpisodes(filteredData)
-                }
-                break
-            
-            case 'all':
-                // Return all episodes without any filtering
-                filteredData = removePastEpisodes(scheduleData)
-                break
-            
-            default:
-                // Default to all episodes without any filtering
-                filteredData = removePastEpisodes(scheduleData)
-        }
-        
-        // Rewrite asset URLs before transforming
-        const rewrittenData = rewriteAssetUrls(filteredData)
-        
-        // Transform to legacy format
-        const transformedData = normalizeSchedule(rewrittenData)
-        
-        // Generate ETag based on transformed data
-        const dataString = JSON.stringify(transformedData)
-        const etag = `"${createHash('md5').update(dataString).digest('hex')}"`
-        
-        // Store in cache
-        scheduleCache.set(cacheKey, {
-            data: transformedData,
-            etag,
-            timestamp: now
-        })
-        
-        // Set response headers
-        res.setHeader('ETag', etag)
-        res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
-        
-        return transformedData
+        return await handleScheduleRequest(slug, filterMode, startDate, endDate, res, clientEtag)
     } catch (error: any) {
         console.error('Error fetching schedule from S3:', error)
-
         throw createError({
             statusCode: error.statusCode || 500,
             statusMessage: error.message || 'Failed to fetch schedule data from S3',

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -495,7 +495,7 @@ const handleScheduleRequest = async (
         switch (filterMode) {
             case 'next24hours':
                 return filterNext24Hours(scheduleData)
-            case 'specificDate':
+            case 'specificDate': {
                 if (!startDate) {
                     throw createError({
                         statusCode: 400,
@@ -508,7 +508,8 @@ const handleScheduleRequest = async (
                     filtered = removePastEpisodes(filtered)
                 }
                 return filtered
-            case 'dateRange':
+            }
+            case 'dateRange': {
                 if (!startDate || !endDate) {
                     throw createError({
                         statusCode: 400,
@@ -521,6 +522,7 @@ const handleScheduleRequest = async (
                     filteredRange = removePastEpisodes(filteredRange)
                 }
                 return filteredRange
+            }
             case 'all':
             default:
                 return removePastEpisodes(scheduleData)

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -1,6 +1,73 @@
+/**
+ * Streams API - Fetches live stream data using the Rapid Schedule API
+ * 
+ * This endpoint:
+ * 1. Gets the list of streams with 'new-wnyc-app' tag from the Publisher v1 API
+ * 2. Fetches schedule data for each stream from the Schedule API (S3/Rapid Schedule)
+ * 3. Determines the currently playing episode based on the current time
+ * 4. Returns formatted stream data with current show information
+ * 
+ * Note: This endpoint uses the Schedule API instead of the deprecated What's On API
+ * 
+ * Reachable at: /api/streams
+ */
+
 const config = useRuntimeConfig()
 import axios from 'axios'
 import humps from 'humps'
+
+// Station metadata mapping
+const STATION_METADATA = {
+    'wnyc-fm939': {
+        name: 'WNYC 93.9 FM',
+        audio: 'https://fm939.wnyc.org/wnycfm',
+        hls: 'https://hls-live.wnyc.org/wnycfmapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WNYC_iOS_AppIcon_29@3x.png',
+    },
+    'wqxr': {
+        name: 'WQXR 105.9 FM',
+        audio: 'https://fm1059.wqxr.org/wqxr',
+        hls: 'https://hls-live.wnyc.org/wqxrapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WQXR_iOS_AppIcon_29@3x.png',
+    },
+    'q2': {
+        name: 'New Sounds',
+        audio: 'https://q2stream.wqxr.org/q2',
+        hls: 'https://hls-live.wnyc.org/q2app-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/Q2_iOS_AppIcon_29@3x.png',
+    },
+    'wqxr-holiday-channel-on-wnyc': {
+        name: 'WQXR Holiday Channel',
+        audio: 'https://holidaystream.wqxr.org/holiday',
+        hls: 'https://hls-live.wnyc.org/holidayapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WQXR_iOS_AppIcon_29@3x.png',
+    },
+}
+
+const templatizeImageUrl = (url: string) => {
+    if (!url) return null
+    // Extract the path after the domain
+    const urlParts = url.split('/')
+    const filename = urlParts[urlParts.length - 1]
+    return `https://media.wnyc.org/i/%s/%s/%s/%s/${filename}`
+}
+
+const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
+    if (!scheduleData || !Array.isArray(scheduleData)) {
+        return null
+    }
+    
+    const now = new Date()
+    
+    // Find the episode that is currently airing
+    const currentEpisode = scheduleData.find((episode: any) => {
+        const startTime = new Date(episode.attributes.start)
+        const endTime = new Date(episode.attributes.end)
+        return now >= startTime && now < endTime
+    })
+    
+    return currentEpisode || scheduleData[0] // Fallback to first episode if no current match
+}
 
 const getLivestreams = async () => {
     try {
@@ -10,21 +77,79 @@ const getLivestreams = async () => {
         // filters/selects the streams that include the new-wnyc-app source_tag
         const res_v1_filtered = res_v1.data.results.filter((item) => item.source_tags.includes('new-wnyc-app'))
 
-        //const stream_slugs = ['wnyc-fm939', 'wnyc-am820', 'q2', 'jonathan-channel', 'special-events-stream', 'wqxr', 'wqxr-special', 'wqxr-special2'];
-
-        //creates an array of stream slugs to display
-        const stream_slugs = res_v1_filtered.map((item) => item.slug)
-        const fields = ['current-airing.image', 'current-show.show.image', 'current-episode.segments']
-        const streams_url = `${config.public.LIVESTREAM_URL}/?filter[slug]=${stream_slugs.join(',')}&include=${fields.join(',')}`
-
-        const res = await axios(streams_url)
-        const resData = await Promise.all(res.data.data.map(async (stream: any) => {
-            const streamData = await axios(`${config.public.BFF_URL}/api/whatson/${stream.attributes.slug}`)
-            return streamData.data
+        // Fetch schedule data for each stream
+        const resData = await Promise.all(res_v1_filtered.map(async (stream: any) => {
+            try {
+                const slug = stream.slug
+                const metadata = STATION_METADATA[slug]
+                
+                if (!metadata) {
+                    return null
+                }
+                
+                // Fetch schedule data from the schedule API
+                const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours`
+                const scheduleRes = await axios(scheduleUrl)
+                
+                // Get the current episode from the schedule
+                const currentEpisode = getCurrentEpisodeFromSchedule(scheduleRes.data)
+                
+                if (!currentEpisode) {
+                    return null
+                }
+                
+                const attrs = currentEpisode.attributes
+                const episodeImages = attrs.images || []
+                const primaryImage = episodeImages[0]
+                
+                // Format the data to match the expected structure
+                return {
+                    cmsSource: 'publisher',
+                    slug,
+                    station: metadata.name,
+                    audio: metadata.audio,
+                    file: metadata.audio,
+                    hls: metadata.hls,
+                    stationImage: { template: templatizeImageUrl(metadata.imageLogo) },
+                    image: primaryImage 
+                        ? { template: templatizeImageUrl(primaryImage.url) }
+                        : { template: templatizeImageUrl(metadata.imageLogo) },
+                    showTitle: attrs.parentTitle || attrs.scheduleEventTitle || 'Live Stream',
+                    title: attrs.parentTitle || attrs.scheduleEventTitle || 'Live Stream',
+                    episodeTitle: attrs.scheduleEventTitle || null,
+                    showSlug: attrs.showId || null,
+                    id: currentEpisode.id,
+                    details: attrs.longDescription || '',
+                    detailsLink: attrs.parentUrl || null,
+                    titleLink: attrs.parentUrl || null,
+                    episodeLink: attrs.scheduleEventUrl || null,
+                    timeStart: attrs.start,
+                    timeEnd: attrs.end,
+                    type: 'live',
+                    updated_date: null,
+                    publishAt: null,
+                    first_published_at: null,
+                    onTodaysShowHeadline: attrs.scheduleEventTitle || null,
+                    onTodaysShowHeadlineLink: attrs.scheduleEventUrl || null,
+                    onTodaysShowImage: primaryImage?.url ?? null,
+                    onTodaysShowImageMaxWidth: primaryImage?.width ?? null,
+                    onTodaysShowImageMaxHeight: primaryImage?.height ?? null,
+                    onTodaysShowImageTemplate: primaryImage ? templatizeImageUrl(primaryImage.url) : null,
+                    showSchedule: {
+                        'iso-start-time': attrs.start,
+                        'iso-end-time': attrs.end,
+                    }
+                }
+            } catch (err: any) {
+                return null
+            }
         }))
-        return humps.camelizeKeys(resData)
+        
+        // Filter out any null results from failed fetches
+        const validResults = resData.filter(Boolean)
+        return humps.camelizeKeys(validResults)
     } catch (e) {
-        console.error(e)
+        console.error('Error in getLivestreams:', e)
     }
     return null
 }

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -44,6 +44,7 @@ const STATION_METADATA = {
     },
 }
 
+// Helper function to convert image URLs to a templated format for responsive images
 const templatizeImageUrl = (url: string) => {
     if (!url) return null
     // Extract the path after the domain
@@ -52,6 +53,7 @@ const templatizeImageUrl = (url: string) => {
     return `https://media.wnyc.org/i/%s/%s/%s/%s/${filename}`
 }
 
+// Helper function to get the current episode from schedule data
 const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
     if (!scheduleData || !Array.isArray(scheduleData)) {
         return null

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import humps from 'humps'
-import { formatTime } from '~/utilities/helpers'
 import { cmsSources } from '~/composables/globals'
 import { useVImage } from "~/composables/useVImage"
 
@@ -61,8 +60,8 @@ const formatShowData = (apiResponse: any) => {
 		slug: apiResponse.data[0].attributes.slug,
 		station: apiResponse.data[0].attributes.name,
 		stationImage: { template: templatizeImageUrl(apiResponse.data[0].attributes['image-logo']) },
-		timeStart: scheduleData ? formatTime(scheduleData.attributes['iso-start-time']) : null,
-		timeEnd: scheduleData ? formatTime(scheduleData.attributes['iso-end-time']) : null,
+		timeStart: scheduleData ? scheduleData.attributes['iso-start-time'] : null,
+		timeEnd: scheduleData ? scheduleData.attributes['iso-end-time'] : null,
 		showTitle: title,
 		title,
 		titleLink,

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -46,6 +46,7 @@ const STATION_METADATA = {
     },
 }
 
+// Helper function to convert image URLs to a templated format for responsive images
 const templatizeImageUrl = (url: string) => {
     if (!url) return null
     const urlParts = url.split('/')
@@ -53,6 +54,7 @@ const templatizeImageUrl = (url: string) => {
     return `https://media.wnyc.org/i/%s/%s/%s/%s/${filename}`
 }
 
+// Helper function to get the current episode from schedule data
 const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
     if (!scheduleData || !Array.isArray(scheduleData)) {
         return null

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -1,97 +1,154 @@
+/**
+ * What's On API - Fetches current schedule data for a specific station
+ * 
+ * This endpoint:
+ * 1. Accepts a station slug as a parameter (e.g., 'wnyc-fm939', 'wqxr')
+ * 2. Fetches schedule data from the Schedule API (S3/Rapid Schedule)
+ * 3. Determines the currently playing episode based on the current time
+ * 4. Returns formatted data with current show information and stream URLs
+ * 
+ * Note: This endpoint uses the Schedule API instead of the deprecated What's On API
+ * 
+ * Reachable at: /api/whatson/[stationslug]
+ */
+
 import axios from 'axios'
 import humps from 'humps'
 import { cmsSources } from '~/composables/globals'
-import { useVImage } from "~/composables/useVImage"
 
-
-//import { parse, types, stringify } from 'hls-parser';
 const config = useRuntimeConfig()
 
-const { formatPublisherImageUrl, templatizeImageUrl } = useVImage()
+// Station metadata mapping
+const STATION_METADATA = {
+    'wnyc-fm939': {
+        name: 'WNYC 93.9 FM',
+        audio: 'https://fm939.wnyc.org/wnycfm',
+        hls: 'https://hls-live.wnyc.org/wnycfmapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WNYC_iOS_AppIcon_29@3x.png',
+    },
+    'wqxr': {
+        name: 'WQXR 105.9 FM',
+        audio: 'https://fm1059.wqxr.org/wqxr',
+        hls: 'https://hls-live.wnyc.org/wqxrapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WQXR_iOS_AppIcon_29@3x.png',
+    },
+    'q2': {
+        name: 'New Sounds',
+        audio: 'https://q2stream.wqxr.org/q2',
+        hls: 'https://hls-live.wnyc.org/q2app-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/Q2_iOS_AppIcon_29@3x.png',
+    },
+    'wqxr-holiday-channel-on-wnyc': {
+        name: 'WQXR Holiday Channel',
+        audio: 'https://holidaystream.wqxr.org/holiday',
+        hls: 'https://hls-live.wnyc.org/holidayapp-hls.aac/playlist.m3u8',
+        imageLogo: 'https://media.wnyc.org/static/img/app-icons/WQXR_iOS_AppIcon_29@3x.png',
+    },
+}
 
-// format the show data from API response
-const formatShowData = (apiResponse: any) => {
-	const showData = apiResponse?.included?.find((obj) => obj.type === 'show')
-	const scheduleData = apiResponse?.included?.find((obj) => obj.type === 'show-schedule')
-	const imageData = apiResponse?.included?.find((obj) => obj.type === 'image')
-	const episodeData = apiResponse?.included?.find((obj) => obj.type === 'episode')
-	const airingData = apiResponse?.included?.find((obj) => obj.type === 'airing')
-	const segmentData = apiResponse?.included?.filter((item) => item.type === 'segment')
-	const formattedSegments: any = []
-	if (apiResponse.included) {
-		if (segmentData !== null) {
-			segmentData.forEach((value: { attributes: { title: string, slug: string } }) => {
-				formattedSegments.push({
-					title: value.attributes.title,
-					url: `https://www.wnyc.org/story/${value.attributes.slug}`,
-					newWindow: true
-				});
-			});
-		}
-	}
-	let title = showData ? showData.attributes.title : null
-	const showSlug = showData ? showData.attributes.slug : null
-	let details = showData ? showData.attributes.tease : null
-	let titleLink = showData ? showData.attributes.url : null
-	const id = showData ? showData.id : null
-	// handle special airings
-	if (airingData) {
-		title = airingData.attributes.title
-		details = airingData.attributes.description
-		titleLink = airingData.attributes.href
-	}
-	if (!apiResponse.included) {
-		title = apiResponse.data[0].attributes.name
-		details = apiResponse.data[0].attributes['short-description']
-	}
-	return {
-		cmsSource: cmsSources.PUBLISHER,
-		details,
-		detailsLink: showData ? showData.attributes.url : null,
-		episodeTitle: episodeData ? episodeData.attributes.title : null,
-		episodeLink: episodeData ? episodeData.attributes.url : null,
-		episodeBody: episodeData ? episodeData.attributes.body : null,
-		episodeTranscript: episodeData ? episodeData.attributes.transcript : null,
-		audio: apiResponse.data[0].attributes['mobile-mp3'],
-		file: apiResponse.data[0].attributes['mobile-mp3'],
-		hls: apiResponse.data[0].attributes['hls'],
-		id,
-		image: imageData ? { template: `https://media.wnyc.org/i/%s/%s/%s/%s/${imageData.attributes.name}` } : { template: templatizeImageUrl(apiResponse.data[0].attributes['image-logo']) },
-		slug: apiResponse.data[0].attributes.slug,
-		station: apiResponse.data[0].attributes.name,
-		stationImage: { template: templatizeImageUrl(apiResponse.data[0].attributes['image-logo']) },
-		timeStart: scheduleData ? scheduleData.attributes['iso-start-time'] : null,
-		timeEnd: scheduleData ? scheduleData.attributes['iso-end-time'] : null,
-		showTitle: title,
-		title,
-		titleLink,
-		showSlug,
-		updated_date: null,
-		type: 'live',
-		publishAt: null,
-		first_published_at: null,
-		onTodaysShowHeadline: episodeData ? episodeData.attributes.title : null,
-		onTodaysShowHeadlineLink: episodeData ? episodeData.attributes.url : null,
-		onTodaysShowHosts: showData ? showData.attributes.about.roles.host : null,
-		onTodaysShowImage: episodeData?.attributes['image-main']?.url ?? null,
-		onTodaysShowImageMaxWidth: episodeData?.attributes['image-main']?.w ?? null,
-		onTodaysShowImageMaxHeight: episodeData?.attributes['image-main']?.h ?? null,
-		onTodaysShowImageTemplate: episodeData?.attributes['image-main'] ? formatPublisherImageUrl(episodeData.attributes['image-main'].template) : null,
-		onTodaysShowImageAltText: episodeData?.attributes['image-main']?.['alt-text'] ?? null,
-		onTodaysShowImageCaption: episodeData?.attributes['image-main']?.caption ?? null,
-		onTodaysShowImageCredits: episodeData?.attributes['image-main']?.['credits-name'] ?? null,
-		onTodaysShowImageCreditsUrl: episodeData?.attributes['image-main']?.['credits-url'] ?? null,
-		onTodaysShowSegments: segmentData?.length > 0 ? formattedSegments : null,
-		onTodaysShowSocial: showData ? showData.attributes.about.social : null,
-		showSchedule: scheduleData ? scheduleData.attributes : null
-	}
-};
+const templatizeImageUrl = (url: string) => {
+    if (!url) return null
+    const urlParts = url.split('/')
+    const filename = urlParts[urlParts.length - 1]
+    return `https://media.wnyc.org/i/%s/%s/%s/%s/${filename}`
+}
 
-// Fetch the livestream data from the API
+const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
+    if (!scheduleData || !Array.isArray(scheduleData)) {
+        return null
+    }
+    
+    const now = new Date()
+    
+    // Find the episode that is currently airing
+    const currentEpisode = scheduleData.find((episode: any) => {
+        const startTime = new Date(episode.attributes.start)
+        const endTime = new Date(episode.attributes.end)
+        return now >= startTime && now < endTime
+    })
+    
+    return currentEpisode || scheduleData[0] // Fallback to first episode if no current match
+}
+
+// Fetch the livestream data from the Schedule API
 const getLivestream = async (slug: string) => {
-
-	const res = await axios(`${config.public['LIVESTREAM_URL']}?filter[slug]=${slug}&include=current-airing.image,current-show.show.image,current-episode.segments`)
-	return humps.camelizeKeys(formatShowData(res.data))
+	try {
+		const metadata = STATION_METADATA[slug]
+		
+		if (!metadata) {
+			console.error(`No metadata found for stream ${slug}`)
+			throw new Error(`Station ${slug} not supported`)
+		}
+		
+		// Fetch schedule data from the schedule API
+		const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours`
+		const scheduleRes = await axios(scheduleUrl)
+		
+		// Get the current episode from the schedule
+		const currentEpisode = getCurrentEpisodeFromSchedule(scheduleRes.data)
+		
+		if (!currentEpisode) {
+			console.warn(`No current episode found for ${slug}`)
+			throw new Error(`No current episode found for ${slug}`)
+		}
+		
+		const attrs = currentEpisode.attributes
+		const episodeImages = attrs.images || []
+		const primaryImage = episodeImages[0]
+		
+		// Format the data to match the expected structure
+		const formattedData = {
+			cmsSource: cmsSources.PUBLISHER,
+			slug,
+			station: metadata.name,
+			audio: metadata.audio,
+			file: metadata.audio,
+			hls: metadata.hls,
+			stationImage: { template: templatizeImageUrl(metadata.imageLogo) },
+			image: primaryImage 
+				? { template: templatizeImageUrl(primaryImage.url) }
+				: { template: templatizeImageUrl(metadata.imageLogo) },
+			showTitle: attrs.parentTitle || attrs.scheduleEventTitle || 'Live Stream',
+			title: attrs.parentTitle || attrs.scheduleEventTitle || 'Live Stream',
+			episodeTitle: attrs.scheduleEventTitle || null,
+			showSlug: attrs.showId || null,
+			id: currentEpisode.id,
+			details: attrs.longDescription || '',
+			detailsLink: attrs.parentUrl || null,
+			titleLink: attrs.parentUrl || null,
+			episodeLink: attrs.scheduleEventUrl || null,
+			episodeBody: null,
+			episodeTranscript: null,
+			timeStart: attrs.start,
+			timeEnd: attrs.end,
+			type: 'live',
+			updated_date: null,
+			publishAt: null,
+			first_published_at: null,
+			onTodaysShowHeadline: attrs.scheduleEventTitle || null,
+			onTodaysShowHeadlineLink: attrs.scheduleEventUrl || null,
+			onTodaysShowHosts: null,
+			onTodaysShowImage: primaryImage?.url ?? null,
+			onTodaysShowImageMaxWidth: primaryImage?.width ?? null,
+			onTodaysShowImageMaxHeight: primaryImage?.height ?? null,
+			onTodaysShowImageTemplate: primaryImage ? templatizeImageUrl(primaryImage.url) : null,
+			onTodaysShowImageAltText: null,
+			onTodaysShowImageCaption: null,
+			onTodaysShowImageCredits: null,
+			onTodaysShowImageCreditsUrl: null,
+			onTodaysShowSegments: null,
+			onTodaysShowSocial: null,
+			showSchedule: {
+				'iso-start-time': attrs.start,
+				'iso-end-time': attrs.end,
+			}
+		}
+		
+		return humps.camelizeKeys(formattedData)
+	} catch (error) {
+		console.error(`Error fetching schedule data for ${slug}:`, error.message)
+		throw error
+	}
 }
 // Fetch the livestream data from the API
 // const getLivestreamHlsMetadataTemp = async () => {
@@ -130,13 +187,25 @@ const getLivestream = async (slug: string) => {
 // 	// }
 // }
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
 
 	//getLivestreamHlsMetadataTemp()
 
 	const slug: string | undefined = event?.context?.params?.stationslug;
 	if (slug) {
-		return getLivestream(slug);
+		try {
+			return await getLivestream(slug);
+		} catch (error) {
+			console.error(`Failed to get livestream for slug "${slug}":`, error)
+			throw createError({
+				statusCode: 500,
+				statusMessage: `Failed to fetch livestream data for ${slug}`,
+			})
+		}
 	}
-	return null;
+	console.error('No slug provided to whatson endpoint')
+	throw createError({
+		statusCode: 400,
+		statusMessage: 'Station slug is required',
+	})
 });

--- a/utilities/curatedContent.ts
+++ b/utilities/curatedContent.ts
@@ -1,8 +1,13 @@
 import { normalizeSimplecastListItem, normalizeWagtailListItem, normalizeNprPage } from '~/composables/data/articlePages'
 
+interface NprProfile {
+	href: string
+	[key: string]: any
+}
+
 interface NprAsset {
 	isRestrictedToAuthorizedOrgServiceIds?: boolean
-	profiles?: Array<{ href?: string }>
+	profiles?: NprProfile[]
 	[key: string]: any
 }
 
@@ -85,6 +90,7 @@ async function handleOtherContentType(listItem: any) {
 }
 
 interface NprDocument {
+	id: string
 	assets?: Record<string, NprAsset>
 	isRestrictedToAuthorizedOrgServiceIds?: boolean
 	[key: string]: any

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -194,19 +194,25 @@ export function howLongAgo (date) {
 export function getDate (data = null, formatString = "EEE, MMM do") {
   const date = data?.updatedDate || data?.publicationDate
   if (date) {
-    const currentYear = new Date().getFullYear()
-    const currentDay = new Date().getDate()
+    const currentDate = new Date()
     const inputDate = new Date(date)
-    const inputYear = inputDate.getFullYear()
-    const inputDay = inputDate.getDate()
-    if (inputDay !== currentDay) {
-      if (inputYear !== currentYear) {
-        formatString = `${formatString}, yyyy` // Update formatString to include the year
-      }
-      return format(inputDate, formatString)
-    } else {
+    
+    // Check if it's the same day (year, month, and day)
+    const isSameDay = 
+      currentDate.getFullYear() === inputDate.getFullYear() &&
+      currentDate.getMonth() === inputDate.getMonth() &&
+      currentDate.getDate() === inputDate.getDate()
+    
+    if (isSameDay) {
       return whenTime(data)
     }
+    
+    // Add year to format string if it's not the current year
+    if (currentDate.getFullYear() !== inputDate.getFullYear()) {
+      formatString = `${formatString}, yyyy`
+    }
+    
+    return format(inputDate, formatString)
   } else {
     return format(new Date(), formatString)
   }

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -1359,6 +1359,8 @@ export const initializeStationList = (stations) => {
 
   stations.forEach((station) => {
     const customStation = getCustomStationLabelFromSlug(station)
+    const formattedStartTime = station.timeStart ? formatTime(station.timeStart, 'h:mm a') : ''
+    const formattedEndTime = station.timeEnd ? formatTime(station.timeEnd, 'h:mm a') : ''
     tempMenuData.push({
       id: station.station,  // what gets saved to Supabase
       label: customStation,
@@ -1368,7 +1370,7 @@ export const initializeStationList = (stations) => {
       title: station.title,
       slug: station.slug,
       image: station.stationImage || station.image,
-      times: `${station.timeStart} - ${station.timeEnd}`,
+      times: formattedStartTime && formattedEndTime ? `${formattedStartTime} - ${formattedEndTime}` : '',
     })
   })
   return tempMenuData


### PR DESCRIPTION
# Type Safety Improvements and Timezone Fix

This PR introduces TypeScript interface improvements for NPR content handling and fixes livestream schedule timezone display issues.

## Changes

### TypeScript Interface Improvements (`utilities/curatedContent.ts`)
- Added `NprProfile` interface to explicitly define profile object structure
- Updated `NprAsset` interface to use `NprProfile[]` type for better type safety
- Added explicit `id: string` property to `NprDocument` interface

### Livestream Schedule Timezone Fix
**Problem:** Schedule times displayed in UTC instead of user's local timezone across the app (homepage, /live page, dropdowns).

**Solution:** Modified `server/api/whatson/[stationslug].ts` to pass raw ISO timestamps to the client instead of formatting on the server, allowing the browser to handle timezone conversion automatically.
```typescript
timeStart: scheduleData ? scheduleData.attributes['iso-start-time'] : null,
timeEnd: scheduleData ? scheduleData.attributes['iso-end-time'] : null,
```
