### PR TITLE
Update WNYC schedule fixture

### DIFF
--- a/server/data/schedules/schedule-wnyc-fm939.json
+++ b/server/data/schedules/schedule-wnyc-fm939.json
@@ -1,3488 +1,3530 @@
 {
-  "episodes": [
-    {
-      "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20251211",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-11T00:00:00.000Z",
-      "endTime": "2025-12-11T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20251211",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "startTime": "2025-12-11T01:00:00.000Z",
-      "endTime": "2025-12-11T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d5c7845d-eace-4600-bddd-b145a7a80d13_20251211",
-      "description": "",
-      "name": "The Moth",
-      "longDescription": "",
-      "showId": "7eb0b8f4-7326-4455-80d1-2b6836464488",
-      "startTime": "2025-12-11T02:00:00.000Z",
-      "endTime": "2025-12-11T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "10ad363d-a493-4468-b12e-45091fa0b872_20251211",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "startTime": "2025-12-11T03:00:00.000Z",
-      "endTime": "2025-12-11T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251211",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-11T04:00:00.000Z",
-      "endTime": "2025-12-11T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20251211",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-11T05:00:00.000Z",
-      "endTime": "2025-12-11T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20251211",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-11T10:00:00.000Z",
-      "endTime": "2025-12-11T11:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20251211",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-11T12:00:00.000Z",
-      "endTime": "2025-12-11T13:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20251211",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-11T14:00:00.000Z",
-      "endTime": "2025-12-11T14:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20251211",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "startTime": "2025-12-11T14:59:00.000Z",
-      "endTime": "2025-12-11T16:59:00.000Z",
-      "duration": "02:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20251211",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "startTime": "2025-12-11T17:00:00.000Z",
-      "endTime": "2025-12-11T18:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20251211",
-      "description": "",
-      "name": "Fresh Air with Terry Gross",
-      "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry's fascinating interviews and features, Fresh Air's stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
-      "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
-      "startTime": "2025-12-11T19:00:00.000Z",
-      "endTime": "2025-12-11T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20251211",
-      "description": "",
-      "name": "1A Hour 1",
-      "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together — welcome to 1A.  \n\nThe conversation isn’t just on air. 1A invites you to join in. We’ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
-      "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
-      "startTime": "2025-12-11T20:00:00.000Z",
-      "endTime": "2025-12-11T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/54e56aea89ed148ba682892ba20680c8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20251211",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-11T21:00:00.000Z",
-      "endTime": "2025-12-11T23:30:00.000Z",
-      "duration": "02:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20251211",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "startTime": "2025-12-11T23:30:00.000Z",
-      "endTime": "2025-12-12T00:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20251212",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-12T00:00:00.000Z",
-      "endTime": "2025-12-12T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20251212",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "startTime": "2025-12-12T01:00:00.000Z",
-      "endTime": "2025-12-12T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "2fca142e-1f3c-45a7-811a-242c67a388a4_20251212",
-      "description": "",
-      "name": "Latino USA",
-      "longDescription": "",
-      "showId": "1a287c7c-af21-4221-8597-6a205a59b283",
-      "startTime": "2025-12-12T02:00:00.000Z",
-      "endTime": "2025-12-12T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "10ad363d-a493-4468-b12e-45091fa0b872_20251212",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "startTime": "2025-12-12T03:00:00.000Z",
-      "endTime": "2025-12-12T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251212",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-12T04:00:00.000Z",
-      "endTime": "2025-12-12T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20251212",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-12T05:00:00.000Z",
-      "endTime": "2025-12-12T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20251212",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-12T10:00:00.000Z",
-      "endTime": "2025-12-12T11:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20251212",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-12T12:00:00.000Z",
-      "endTime": "2025-12-12T13:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20251212",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-12T14:00:00.000Z",
-      "endTime": "2025-12-12T14:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20251212",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "startTime": "2025-12-12T14:59:00.000Z",
-      "endTime": "2025-12-12T16:59:00.000Z",
-      "duration": "02:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20251212",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "startTime": "2025-12-12T17:00:00.000Z",
-      "endTime": "2025-12-12T18:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "5b575c76-bfcc-4acb-bb3e-c2f85f8b67df_20251212",
-      "description": "",
-      "name": "Science Friday Hour 1",
-      "longDescription": "Hour 1:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
-      "showId": "a4d7b6c6-63ee-4d7a-9861-85dfe951fab2",
-      "startTime": "2025-12-12T19:00:00.000Z",
-      "endTime": "2025-12-12T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4e20aba1-2d6b-482d-8ca8-f4f964e5f4ed_20251212",
-      "description": "",
-      "name": "Science Friday Hour 2",
-      "longDescription": "Hour 2:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
-      "showId": "92250676-a072-497e-8ff9-354fca52daa1",
-      "startTime": "2025-12-12T20:00:00.000Z",
-      "endTime": "2025-12-12T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20251212",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-12T21:00:00.000Z",
-      "endTime": "2025-12-12T23:30:00.000Z",
-      "duration": "02:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20251212",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "startTime": "2025-12-12T23:30:00.000Z",
-      "endTime": "2025-12-13T00:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20251213",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-13T00:00:00.000Z",
-      "endTime": "2025-12-13T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": true
-    },
-    {
-      "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20251213",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "startTime": "2025-12-13T01:00:00.000Z",
-      "endTime": "2025-12-13T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "c7069dc9-b49f-47be-b01e-10d38181d97a_20251213",
-      "description": "",
-      "name": "On The Media",
-      "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
-      "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
-      "startTime": "2025-12-13T02:00:00.000Z",
-      "endTime": "2025-12-13T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/839c1936fdd317120deebb5a0cd630ec.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "10ad363d-a493-4468-b12e-45091fa0b872_20251213",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "startTime": "2025-12-13T03:00:00.000Z",
-      "endTime": "2025-12-13T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251213",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-13T04:00:00.000Z",
-      "endTime": "2025-12-13T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "e3c31d77-ddfe-4a08-9a72-298593a44456_20251213",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-13T05:00:00.000Z",
-      "endTime": "2025-12-13T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "a38b98da-9dac-41ce-9f0a-7069615e743b_20251213",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-13T10:00:00.000Z",
-      "endTime": "2025-12-13T10:29:00.000Z",
-      "duration": "00:29:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6049170d-8fd2-42db-89b0-191711994ea7_20251213",
-      "description": "",
-      "name": "The Capitol Connection",
-      "longDescription": "",
-      "showId": "4ca6af26-1207-49f5-b244-539538595c11",
-      "startTime": "2025-12-13T10:30:00.000Z",
-      "endTime": "2025-12-13T11:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "858bebbe-046c-4cfe-b15f-8f8aa3d30e76_20251213",
-      "description": "",
-      "name": "The Pulse",
-      "longDescription": "",
-      "showId": "0fd1be5c-9e07-4d7c-ba3c-7b108cf48ce5",
-      "startTime": "2025-12-13T11:00:00.000Z",
-      "endTime": "2025-12-13T12:00:00.000Z",
-      "duration": "01:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d9db694b-1589-4eb2-b531-4c634c8a2597_20251213",
-      "description": "",
-      "name": "On The Media",
-      "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
-      "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
-      "startTime": "2025-12-13T12:00:00.000Z",
-      "endTime": "2025-12-13T12:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/839c1936fdd317120deebb5a0cd630ec.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9728a227-6a82-476b-9bba-d91c5cdef7ac_20251213",
-      "description": "",
-      "name": "Weekend Edition Saturday",
-      "longDescription": "NPR's two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
-      "showId": "a247770a-afbd-4d8f-88df-7a5594f93177",
-      "startTime": "2025-12-13T13:00:00.000Z",
-      "endTime": "2025-12-13T14:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/658ac7f45bfda071fd7b440d20816bdb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "a65f03b9-697c-437a-aff6-c786e8d8ffa2_20251213",
-      "description": "",
-      "name": "The New Yorker Radio Hour",
-      "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine’s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine’s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
-      "showId": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
-      "startTime": "2025-12-13T15:00:00.000Z",
-      "endTime": "2025-12-13T15:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/9a96007e3fd1468573a640ca4301437b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9e2e2644-fb5e-4d7f-8a31-5f293dd57c4d_20251213",
-      "description": "",
-      "name": "Wait Wait... Don't Tell Me!",
-      "longDescription": "For a wacky and whip-smart approach to the week's news and newsmakers, listen no further than Wait Wait...Don't Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week's events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
-      "showId": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
-      "startTime": "2025-12-13T16:00:00.000Z",
-      "endTime": "2025-12-13T16:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4b14521d-f99f-4157-8809-2313074d1fce_20251213",
-      "description": "",
-      "name": "Radiolab",
-      "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It's Technicolor radio. Radiolab is produced and distributed by WNYC.",
-      "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
-      "startTime": "2025-12-13T17:00:00.000Z",
-      "endTime": "2025-12-13T17:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/85374fff377cc8b938f797c3c22f5afe.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "925a88aa-8ae6-4bdc-8d5d-79fb61ea4ae4_20251213",
-      "description": "",
-      "name": "Snap Judgement",
-      "longDescription": "",
-      "showId": "bf196f81-70c5-485e-b90d-f82a0ebcfc74",
-      "startTime": "2025-12-13T18:00:00.000Z",
-      "endTime": "2025-12-13T18:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "30f3b776-45d4-4478-abf7-ce01fe235dbd_20251213",
-      "description": "",
-      "name": "It's Been a Minute",
-      "longDescription": "",
-      "showId": "85557c4e-00dc-4b6a-9856-0c6de5d2ac96",
-      "startTime": "2025-12-13T19:00:00.000Z",
-      "endTime": "2025-12-13T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "7c9ae210-5711-40ad-9803-fd24341ead6c_20251213",
-      "description": "",
-      "name": "Planet Money and How I Built This",
-      "longDescription": "Planet Money explains the economy with playful storytelling and Peabody award-winning deep dive, roll up your sleeves journalism. The team includes Adrian Ma, Mary Childs, Amanda Aronczyk, Jeff Guo, Nick Fountain, Erika Beras, Sarah Gonzalez, Robert Smith and Kenny Malone.\n\nGuy Raz hosts How I Built This, where innovators, entrepreneurs, and idealists take us through the often challenging journeys they took to build their now iconic companies. Featured guests include the founders of Lyft, Patagonia, Zappos, Spanx, Samuel Adams, Instagram, and more",
-      "showId": "aaf6bcf3-efca-4069-8b31-bc11e6262f16",
-      "startTime": "2025-12-13T20:00:00.000Z",
-      "endTime": "2025-12-13T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/dbfe72c6680bf8c47f316dff13cd568f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "707e9d18-c35e-4151-a748-dacadede8d12_20251213",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-13T21:00:00.000Z",
-      "endTime": "2025-12-13T21:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6a487302-b7a8-4783-93de-1e62e8f51626_20251213",
-      "description": "",
-      "name": "All Things Considered Weekend",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
-      "startTime": "2025-12-13T22:00:00.000Z",
-      "endTime": "2025-12-13T22:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "2eb26a0c-8248-4dc5-a531-4200cd7a2189_20251213",
-      "description": "",
-      "name": "Open to Debate",
-      "longDescription": "America is more divided than ever—but it doesn’t have to be. Open to Debate offers an antidote to the chaos. We bring multiple perspectives together for real debates. Debates that are structured, respectful, clever, provocative, and driven by the facts. Open to Debate is on a mission to restore balance to the public square through expert moderation, good-faith arguments, and reasoned analysis. We examine the issues of the day with the world’s most influential thinkers spanning science, technology, politics, culture, and global affairs. It’s time to build a stronger, more united democracy with the civil exchange of ideas. Be open-minded. Be curious. Be ready to listen. Join us in being Open to Debate.",
-      "showId": "6e625ebf-d7e7-4c1b-a8c6-9567b55ef0ea",
-      "startTime": "2025-12-13T23:00:00.000Z",
-      "endTime": "2025-12-13T23:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/f8c10241898580805b224da5429c4b78.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "c4f10397-09f8-4743-a412-88be9648f2a9_20251214",
-      "description": "",
-      "name": "Fresh Air Weekend",
-      "longDescription": "Look to Fresh Air Weekend for highlights of some of the best interviews and reviews from past weeks, and new program elements specially paced for weekends. Fresh Air Weekend emphasizes interviews with writers, filmmakers, actors, and musicians, and often includes excerpts from live in-studio concerts. Many of the most popular reviewers from weekday Fresh Air can also be heard on Fresh Air Weekend sharing insights into recent movies, music, and books. And there's more. Special segments, including reviews of recently released videos, have been added to the program for additional weekend appeal.\n\nFresh Air Weekend is everything you already love about Fresh Air -- tailored for Saturday and Sunday.",
-      "showId": "d57e1486-0e22-40b6-beac-2afd890d2ee2",
-      "startTime": "2025-12-14T00:00:00.000Z",
-      "endTime": "2025-12-14T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "939bb17d-b315-4f90-81c4-1bed18780103_20251214",
-      "description": "",
-      "name": "Latino USA",
-      "longDescription": "",
-      "showId": "1a287c7c-af21-4221-8597-6a205a59b283",
-      "startTime": "2025-12-14T01:00:00.000Z",
-      "endTime": "2025-12-14T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "68580d5e-38e7-4941-bbd6-af95b7fe4323_20251214",
-      "description": "",
-      "name": "Bullseye with Jesse Thorn",
-      "longDescription": "",
-      "showId": "06af8775-f2c6-436c-96aa-bc45796df19d",
-      "startTime": "2025-12-14T02:00:00.000Z",
-      "endTime": "2025-12-14T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "a484dae9-494b-41e0-bf8d-8e0bf44323fd_20251214",
-      "description": "",
-      "name": "Live Wire with Luke Burbank",
-      "longDescription": "",
-      "showId": "288f67ce-4c74-438a-a5ac-6e57b77a8b58",
-      "startTime": "2025-12-14T03:00:00.000Z",
-      "endTime": "2025-12-14T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251214",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-14T04:00:00.000Z",
-      "endTime": "2025-12-14T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "f364f5ff-7386-44db-a185-4d79a371600a_20251214",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-14T05:00:00.000Z",
-      "endTime": "2025-12-14T11:00:00.000Z",
-      "duration": "06:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "87826193-0ce0-43cb-a725-833b8e961872_20251214",
-      "description": "",
-      "name": "The Splendid Table",
-      "longDescription": "The Splendid Table has been celebrating the intersection of food and life for more than two decades. A culinary, culture and lifestyle program, it has hosted our nation's conversations about cooking, sustainability and food culture and has introduced us to generations of food dignitaries.\n\nRecently, Francis Lam was named host of the show. A regular contributor and frequent guest host on The Splendid Table since 2010, Lam is the former Eat columnist for The New York Times Magazine and is Editor-at-Large at Clarkson Potter, a division within Penguin Random House that is a leader in cookbook publishing. In his tenure at Clarkson Potter, he has been the editor behind some of the most creative and best-selling cookbooks and has worked with acclaimed authors, some of the country's hottest restaurateurs and chefs, as well as celebrities Chrissy Teigen and Questlove. For two seasons, Lam was a regular judge on Bravo's hit show, Top Chef Masters, a spinoff of Top Chef, where world-renowned chefs competed against each other in weekly challenges.\n\nThe show has been listed on numerous \"best of\" podcast lists including a recent nod by the Huffington Post's Food Editor as the top food podcast...",
-      "showId": "210f8cb2-1aa5-4f51-be53-841b667f49a1",
-      "startTime": "2025-12-14T11:00:00.000Z",
-      "endTime": "2025-12-14T12:00:00.000Z",
-      "duration": "01:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/c1f72b2068d545ef5c24dd7367dc49bb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "56bbd484-d280-49a8-8593-f408dd4f7fde_20251214",
-      "description": "",
-      "name": "The Capitol Pressroom",
-      "longDescription": "",
-      "showId": "faf058e8-0dbe-43ed-ad59-6a788594fe74",
-      "startTime": "2025-12-14T12:00:00.000Z",
-      "endTime": "2025-12-14T13:00:00.000Z",
-      "duration": "01:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "45ec041c-677d-43ed-be29-a619a4e39ccc_20251214",
-      "description": "",
-      "name": "Weekend Edition Sunday",
-      "longDescription": "NPR's two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
-      "showId": "0762826a-5320-4e2d-94f3-b37de4acbd7f",
-      "startTime": "2025-12-14T13:00:00.000Z",
-      "endTime": "2025-12-14T14:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/658ac7f45bfda071fd7b440d20816bdb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "26a06f24-6660-4588-afcb-13d920c33260_20251214",
-      "description": "",
-      "name": "On The Media",
-      "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
-      "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
-      "startTime": "2025-12-14T15:00:00.000Z",
-      "endTime": "2025-12-14T15:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/839c1936fdd317120deebb5a0cd630ec.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "1dbc5c18-c216-4ab1-baca-bc5c56c813b9_20251214",
-      "description": "",
-      "name": "Reveal",
-      "longDescription": "",
-      "showId": "947bc247-45a4-4257-aa9a-66d3881341a4",
-      "startTime": "2025-12-14T16:00:00.000Z",
-      "endTime": "2025-12-14T17:00:00.000Z",
-      "duration": "01:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "64cf3b77-c99a-48c1-9e17-2798d2b2914e_20251214",
-      "description": "",
-      "name": "This American Live",
-      "longDescription": "",
-      "showId": "4b9b1a33-6ce7-4602-8e4f-d14b4f33a358",
-      "startTime": "2025-12-14T17:00:00.000Z",
-      "endTime": "2025-12-14T17:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "e02c642a-a7cb-4de8-ad23-684a8606fa7a_20251214",
-      "description": "",
-      "name": "Freakonomics Radio",
-      "longDescription": "Freakonomics Radio ferrets out connections between seemingly unrelated things. The program explores the riddles of everyday life and the weird wrinkles of human nature— from cheating and crime to parenting and sports— using the tools of economics to explore real-world behavior. \n\nHost Stephen J. Dubner discovers the hidden side of everything in interviews with Nobel laureates and provocateurs, social scientists and entrepreneurs — and with his “Freakonomics” co-author Steve Levitt.",
-      "showId": "e966192a-df3b-42a4-b384-28ca0d0038f7",
-      "startTime": "2025-12-14T18:00:00.000Z",
-      "endTime": "2025-12-14T18:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/95873dda648006099ce427ea8dccc39f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "fc6db6d9-ee33-4a6e-ac6e-b7181a5e3967_20251214",
-      "description": "",
-      "name": "Wait Wait... Don't Tell Me!",
-      "longDescription": "For a wacky and whip-smart approach to the week's news and newsmakers, listen no further than Wait Wait...Don't Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week's events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
-      "showId": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
-      "startTime": "2025-12-14T19:00:00.000Z",
-      "endTime": "2025-12-14T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "ae79470a-a4ed-402e-bee6-baa22a2a1823_20251214",
-      "description": "",
-      "name": "The New Yorker Radio Hour",
-      "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine’s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine’s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
-      "showId": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
-      "startTime": "2025-12-14T20:00:00.000Z",
-      "endTime": "2025-12-14T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/9a96007e3fd1468573a640ca4301437b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8408f165-62f1-4052-b35e-e0dd0833b7ba_20251214",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-14T21:00:00.000Z",
-      "endTime": "2025-12-14T21:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6a487302-b7a8-4783-93de-1e62e8f51626_20251214",
-      "description": "",
-      "name": "All Things Considered Weekend",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
-      "startTime": "2025-12-14T22:00:00.000Z",
-      "endTime": "2025-12-14T22:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "5d37b8dc-cb4d-4c6f-94e3-c531adf21d49_20251214",
-      "description": "",
-      "name": "Radiolab",
-      "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It's Technicolor radio. Radiolab is produced and distributed by WNYC.",
-      "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
-      "startTime": "2025-12-14T23:00:00.000Z",
-      "endTime": "2025-12-14T23:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/85374fff377cc8b938f797c3c22f5afe.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "b63a81db-9f17-43ea-94ee-05d06a5f762c_20251215",
-      "description": "",
-      "name": "Throughline",
-      "longDescription": "",
-      "showId": "b604081d-5220-4092-9fec-20c90981652b",
-      "startTime": "2025-12-15T00:00:00.000Z",
-      "endTime": "2025-12-15T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "0c706d89-4d61-4851-9eb4-81f01f46cc63_20251215",
-      "description": "",
-      "name": "TED Radio Hour",
-      "longDescription": "TED Radio Hour investigates the biggest questions of our time with the help of the world’s greatest thinkers. Can we preserve our humanity in the digital age? Where does creativity come from? And what's the secret to living longer? In each episode, host Manoush Zomorodi explores a big idea through a series of TED Talks and original interviews, inspiring us to learn more about the world, our communities, and most importantly, ourselves.",
-      "showId": "254604f0-77c5-4ff2-9ccf-6ad5e298adf8",
-      "startTime": "2025-12-15T01:00:00.000Z",
-      "endTime": "2025-12-15T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b54406a5366faa3f92802b50f9623e90.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9fd133c4-9c08-467a-8ed5-65b0d9fd51d2_20251215",
-      "description": "",
-      "name": "The Moth",
-      "longDescription": "",
-      "showId": "7eb0b8f4-7326-4455-80d1-2b6836464488",
-      "startTime": "2025-12-15T02:00:00.000Z",
-      "endTime": "2025-12-15T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "34a4da6e-47bf-4a97-8f26-97611d716a94_20251215",
-      "description": "",
-      "name": "Selected Shorts",
-      "longDescription": "Our greatest actors transport us through the magic of fiction, one short story at a time. Sometimes funny. Always moving. Selected Shorts is the weekly program that connects you to the world with a rich diversity of voices from literature, film, theater, and comedy. From Symphony Space.\n\n“One of the finest evenings at the theatre.” David Sedaris \n\nSelected Shorts presents some best-loved selections of classic and contemporary short fiction read by acclaimed actors and recorded live at Symphony Space in New York City. Stories are alternately funny, sad, moving, and exciting and make a perfect accompaniment to daily activities. Some of the finest artists of the American theater and screen come through the doors of Symphony Space in a typical season. It is from these recordings that the radio show is produced. For almost three decades, performances have featured works by contemporary greats; as well as the fresh, vivid and diverse works of a new generation of remarkable literary talents. Distinguished works by classic masters such as Edith Wharton, James Thurber, James Baldwin, Shirley Jackson and Edgar Allan Poe have been thrilling audiences for years.\n\nMore than 80 stories are...",
-      "showId": "136c8bd0-f2ce-4efd-87b3-399171c8288a",
-      "startTime": "2025-12-15T03:00:00.000Z",
-      "endTime": "2025-12-15T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b2ed4a01ed98b454116837ce551f2fe7.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251215",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-15T04:00:00.000Z",
-      "endTime": "2025-12-15T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20251215",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-15T05:00:00.000Z",
-      "endTime": "2025-12-15T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20251215",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-15T10:00:00.000Z",
-      "endTime": "2025-12-15T11:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20251215",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-15T12:00:00.000Z",
-      "endTime": "2025-12-15T13:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20251215",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-15T14:00:00.000Z",
-      "endTime": "2025-12-15T14:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20251215",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "startTime": "2025-12-15T14:59:00.000Z",
-      "endTime": "2025-12-15T16:59:00.000Z",
-      "duration": "02:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20251215",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "startTime": "2025-12-15T17:00:00.000Z",
-      "endTime": "2025-12-15T18:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20251215",
-      "description": "",
-      "name": "Fresh Air with Terry Gross",
-      "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry's fascinating interviews and features, Fresh Air's stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
-      "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
-      "startTime": "2025-12-15T19:00:00.000Z",
-      "endTime": "2025-12-15T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20251215",
-      "description": "",
-      "name": "1A Hour 1",
-      "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together — welcome to 1A.  \n\nThe conversation isn’t just on air. 1A invites you to join in. We’ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
-      "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
-      "startTime": "2025-12-15T20:00:00.000Z",
-      "endTime": "2025-12-15T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/54e56aea89ed148ba682892ba20680c8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20251215",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-15T21:00:00.000Z",
-      "endTime": "2025-12-15T23:30:00.000Z",
-      "duration": "02:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20251215",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "startTime": "2025-12-15T23:30:00.000Z",
-      "endTime": "2025-12-16T00:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20251216",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-16T00:00:00.000Z",
-      "endTime": "2025-12-16T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20251216",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "startTime": "2025-12-16T01:00:00.000Z",
-      "endTime": "2025-12-16T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "30a3ab82-6938-44ac-acca-32b355bb11be_20251216",
-      "description": "",
-      "name": "Radiolab",
-      "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It's Technicolor radio. Radiolab is produced and distributed by WNYC.",
-      "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
-      "startTime": "2025-12-16T02:00:00.000Z",
-      "endTime": "2025-12-16T02:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/85374fff377cc8b938f797c3c22f5afe.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "10ad363d-a493-4468-b12e-45091fa0b872_20251216",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "startTime": "2025-12-16T03:00:00.000Z",
-      "endTime": "2025-12-16T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251216",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-16T04:00:00.000Z",
-      "endTime": "2025-12-16T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20251216",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-16T05:00:00.000Z",
-      "endTime": "2025-12-16T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20251216",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-16T10:00:00.000Z",
-      "endTime": "2025-12-16T11:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20251216",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-16T12:00:00.000Z",
-      "endTime": "2025-12-16T13:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20251216",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-16T14:00:00.000Z",
-      "endTime": "2025-12-16T14:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20251216",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "startTime": "2025-12-16T14:59:00.000Z",
-      "endTime": "2025-12-16T16:59:00.000Z",
-      "duration": "02:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20251216",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "startTime": "2025-12-16T17:00:00.000Z",
-      "endTime": "2025-12-16T18:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20251216",
-      "description": "",
-      "name": "Fresh Air with Terry Gross",
-      "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry's fascinating interviews and features, Fresh Air's stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
-      "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
-      "startTime": "2025-12-16T19:00:00.000Z",
-      "endTime": "2025-12-16T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20251216",
-      "description": "",
-      "name": "1A Hour 1",
-      "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together — welcome to 1A.  \n\nThe conversation isn’t just on air. 1A invites you to join in. We’ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
-      "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
-      "startTime": "2025-12-16T20:00:00.000Z",
-      "endTime": "2025-12-16T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/54e56aea89ed148ba682892ba20680c8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20251216",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-16T21:00:00.000Z",
-      "endTime": "2025-12-16T23:30:00.000Z",
-      "duration": "02:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20251216",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "startTime": "2025-12-16T23:30:00.000Z",
-      "endTime": "2025-12-17T00:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20251217",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-17T00:00:00.000Z",
-      "endTime": "2025-12-17T00:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20251217",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "startTime": "2025-12-17T01:00:00.000Z",
-      "endTime": "2025-12-17T01:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "20e7611b-aacc-4919-bfd0-e9fc280e673f_20251217",
-      "description": "",
-      "name": "Reveal",
-      "longDescription": "",
-      "showId": "947bc247-45a4-4257-aa9a-66d3881341a4",
-      "startTime": "2025-12-17T02:00:00.000Z",
-      "endTime": "2025-12-17T03:00:00.000Z",
-      "duration": "01:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "10ad363d-a493-4468-b12e-45091fa0b872_20251217",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "startTime": "2025-12-17T03:00:00.000Z",
-      "endTime": "2025-12-17T03:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20251217",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "startTime": "2025-12-17T04:00:00.000Z",
-      "endTime": "2025-12-17T04:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20251217",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-17T05:00:00.000Z",
-      "endTime": "2025-12-17T10:00:00.000Z",
-      "duration": "05:00:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20251217",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-17T10:00:00.000Z",
-      "endTime": "2025-12-17T11:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20251217",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "startTime": "2025-12-17T12:00:00.000Z",
-      "endTime": "2025-12-17T13:50:00.000Z",
-      "duration": "01:50:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20251217",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "startTime": "2025-12-17T14:00:00.000Z",
-      "endTime": "2025-12-17T14:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20251217",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "startTime": "2025-12-17T14:59:00.000Z",
-      "endTime": "2025-12-17T16:59:00.000Z",
-      "duration": "02:00:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20251217",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "startTime": "2025-12-17T17:00:00.000Z",
-      "endTime": "2025-12-17T18:59:00.000Z",
-      "duration": "01:59:00",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20251217",
-      "description": "",
-      "name": "Fresh Air with Terry Gross",
-      "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry's fascinating interviews and features, Fresh Air's stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
-      "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
-      "startTime": "2025-12-17T19:00:00.000Z",
-      "endTime": "2025-12-17T19:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20251217",
-      "description": "",
-      "name": "1A Hour 1",
-      "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together — welcome to 1A.  \n\nThe conversation isn’t just on air. 1A invites you to join in. We’ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
-      "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
-      "startTime": "2025-12-17T20:00:00.000Z",
-      "endTime": "2025-12-17T20:59:00.000Z",
-      "duration": "00:59:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/54e56aea89ed148ba682892ba20680c8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20251217",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "startTime": "2025-12-17T21:00:00.000Z",
-      "endTime": "2025-12-17T23:30:00.000Z",
-      "duration": "02:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    },
-    {
-      "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20251217",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "startTime": "2025-12-17T23:30:00.000Z",
-      "endTime": "2025-12-18T00:00:00.000Z",
-      "duration": "00:30:00",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": [],
-      "temporaryChanges": false
-    }
-  ],
-  "shows": [
-    {
-      "id": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
-      "description": "",
-      "name": "1A Hour 1",
-      "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together — welcome to 1A.  \n\nThe conversation isn’t just on air. 1A invites you to join in. We’ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/54e56aea89ed148ba682892ba20680c8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "798fc143-0fca-4200-8797-cb6ac566be13",
-      "description": "",
-      "name": "All Of It",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "3a025731-f18a-4dac-ac03-746da53cf2e2",
-      "description": "",
-      "name": "All Things Considered",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
-      "description": "",
-      "name": "All Things Considered Weekend",
-      "longDescription": "NPR's afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/32ed91573acc9d96b395e378866b158f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
-      "description": "",
-      "name": "BBC (APM) World Service",
-      "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/01809b98a2c2a7552a96e6076d00c179.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "06af8775-f2c6-436c-96aa-bc45796df19d",
-      "description": "",
-      "name": "Bullseye with Jesse Thorn",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "e966192a-df3b-42a4-b384-28ca0d0038f7",
-      "description": "",
-      "name": "Freakonomics Radio",
-      "longDescription": "Freakonomics Radio ferrets out connections between seemingly unrelated things. The program explores the riddles of everyday life and the weird wrinkles of human nature— from cheating and crime to parenting and sports— using the tools of economics to explore real-world behavior. \n\nHost Stephen J. Dubner discovers the hidden side of everything in interviews with Nobel laureates and provocateurs, social scientists and entrepreneurs — and with his “Freakonomics” co-author Steve Levitt.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/95873dda648006099ce427ea8dccc39f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "d57e1486-0e22-40b6-beac-2afd890d2ee2",
-      "description": "",
-      "name": "Fresh Air Weekend",
-      "longDescription": "Look to Fresh Air Weekend for highlights of some of the best interviews and reviews from past weeks, and new program elements specially paced for weekends. Fresh Air Weekend emphasizes interviews with writers, filmmakers, actors, and musicians, and often includes excerpts from live in-studio concerts. Many of the most popular reviewers from weekday Fresh Air can also be heard on Fresh Air Weekend sharing insights into recent movies, music, and books. And there's more. Special segments, including reviews of recently released videos, have been added to the program for additional weekend appeal.\n\nFresh Air Weekend is everything you already love about Fresh Air -- tailored for Saturday and Sunday.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "4dd97838-74ac-4467-bd73-859b06040d4f",
-      "description": "",
-      "name": "Fresh Air with Terry Gross",
-      "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry's fascinating interviews and features, Fresh Air's stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/79b10329f3d91babd250b9dcdd82c274.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "85557c4e-00dc-4b6a-9856-0c6de5d2ac96",
-      "description": "",
-      "name": "It's Been a Minute",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "1a287c7c-af21-4221-8597-6a205a59b283",
-      "description": "",
-      "name": "Latino USA",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "288f67ce-4c74-438a-a5ac-6e57b77a8b58",
-      "description": "",
-      "name": "Live Wire with Luke Burbank",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
-      "description": "",
-      "name": "Marketplace",
-      "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/e32b012dd07cddc0c9f66b80d0f64804.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "14cb2422-825d-4ff5-9b82-8f71a312630c",
-      "description": "",
-      "name": "Morning Edition",
-      "longDescription": "NPR's weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/1e823436f4b4348b491b13e28ccb4c40.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "6d06216f-0819-4d14-929c-8c26a14e5eda",
-      "description": "",
-      "name": "New Sounds",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
-      "description": "",
-      "name": "On Point from APM",
-      "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/18f34f42da9c91ba3a527f14c3344df8.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "0fad500e-1128-442c-89c7-ce6d851911ee",
-      "description": "",
-      "name": "On The Media",
-      "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/839c1936fdd317120deebb5a0cd630ec.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "6e625ebf-d7e7-4c1b-a8c6-9567b55ef0ea",
-      "description": "",
-      "name": "Open to Debate",
-      "longDescription": "America is more divided than ever—but it doesn’t have to be. Open to Debate offers an antidote to the chaos. We bring multiple perspectives together for real debates. Debates that are structured, respectful, clever, provocative, and driven by the facts. Open to Debate is on a mission to restore balance to the public square through expert moderation, good-faith arguments, and reasoned analysis. We examine the issues of the day with the world’s most influential thinkers spanning science, technology, politics, culture, and global affairs. It’s time to build a stronger, more united democracy with the civil exchange of ideas. Be open-minded. Be curious. Be ready to listen. Join us in being Open to Debate.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/f8c10241898580805b224da5429c4b78.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "aaf6bcf3-efca-4069-8b31-bc11e6262f16",
-      "description": "",
-      "name": "Planet Money and How I Built This",
-      "longDescription": "Planet Money explains the economy with playful storytelling and Peabody award-winning deep dive, roll up your sleeves journalism. The team includes Adrian Ma, Mary Childs, Amanda Aronczyk, Jeff Guo, Nick Fountain, Erika Beras, Sarah Gonzalez, Robert Smith and Kenny Malone.\n\nGuy Raz hosts How I Built This, where innovators, entrepreneurs, and idealists take us through the often challenging journeys they took to build their now iconic companies. Featured guests include the founders of Lyft, Patagonia, Zappos, Spanx, Samuel Adams, Instagram, and more",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/dbfe72c6680bf8c47f316dff13cd568f.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
-      "description": "",
-      "name": "q from the CBC ",
-      "longDescription": "\"q\" is a lively arts, culture and entertainment magazine. It's a smart and surprising tour through personalities and cultural issues that matter. \n\n\"q\" covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests — Bonnie Raitt, Matthew  McConaughey, k.d. lang and more — the program explores such provocative topics as the branding of politicians or whether \"cougar\" should be embraced or discarded by older women. \"q\" presents big names, big ideas and those paving the way in the cultural community. \n\n\"q\" — a cultural intervention!",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/7e63555d96b9802d8687d08a68cadc7b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
-      "description": "",
-      "name": "Radiolab",
-      "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It's Technicolor radio. Radiolab is produced and distributed by WNYC.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/85374fff377cc8b938f797c3c22f5afe.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "947bc247-45a4-4257-aa9a-66d3881341a4",
-      "description": "",
-      "name": "Reveal",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "a4d7b6c6-63ee-4d7a-9861-85dfe951fab2",
-      "description": "",
-      "name": "Science Friday Hour 1",
-      "longDescription": "Hour 1:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "92250676-a072-497e-8ff9-354fca52daa1",
-      "description": "",
-      "name": "Science Friday Hour 2",
-      "longDescription": "Hour 2:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "136c8bd0-f2ce-4efd-87b3-399171c8288a",
-      "description": "",
-      "name": "Selected Shorts",
-      "longDescription": "Our greatest actors transport us through the magic of fiction, one short story at a time. Sometimes funny. Always moving. Selected Shorts is the weekly program that connects you to the world with a rich diversity of voices from literature, film, theater, and comedy. From Symphony Space.\n\n“One of the finest evenings at the theatre.” David Sedaris \n\nSelected Shorts presents some best-loved selections of classic and contemporary short fiction read by acclaimed actors and recorded live at Symphony Space in New York City. Stories are alternately funny, sad, moving, and exciting and make a perfect accompaniment to daily activities. Some of the finest artists of the American theater and screen come through the doors of Symphony Space in a typical season. It is from these recordings that the radio show is produced. For almost three decades, performances have featured works by contemporary greats; as well as the fresh, vivid and diverse works of a new generation of remarkable literary talents. Distinguished works by classic masters such as Edith Wharton, James Thurber, James Baldwin, Shirley Jackson and Edgar Allan Poe have been thrilling audiences for years.\n\nMore than 80 stories are...",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b2ed4a01ed98b454116837ce551f2fe7.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "bf196f81-70c5-485e-b90d-f82a0ebcfc74",
-      "description": "",
-      "name": "Snap Judgement",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "254604f0-77c5-4ff2-9ccf-6ad5e298adf8",
-      "description": "",
-      "name": "TED Radio Hour",
-      "longDescription": "TED Radio Hour investigates the biggest questions of our time with the help of the world’s greatest thinkers. Can we preserve our humanity in the digital age? Where does creativity come from? And what's the secret to living longer? In each episode, host Manoush Zomorodi explores a big idea through a series of TED Talks and original interviews, inspiring us to learn more about the world, our communities, and most importantly, ourselves.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b54406a5366faa3f92802b50f9623e90.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
-      "description": "",
-      "name": "The Brian Lehrer Show",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/aa0db0e7a95ca44cf02419ecad32805c.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "4ca6af26-1207-49f5-b244-539538595c11",
-      "description": "",
-      "name": "The Capitol Connection",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "faf058e8-0dbe-43ed-ad59-6a788594fe74",
-      "description": "",
-      "name": "The Capitol Pressroom",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "7eb0b8f4-7326-4455-80d1-2b6836464488",
-      "description": "",
-      "name": "The Moth",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
-      "description": "",
-      "name": "The New Yorker Radio Hour",
-      "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine’s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine’s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/9a96007e3fd1468573a640ca4301437b.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "0fd1be5c-9e07-4d7c-ba3c-7b108cf48ce5",
-      "description": "",
-      "name": "The Pulse",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "210f8cb2-1aa5-4f51-be53-841b667f49a1",
-      "description": "",
-      "name": "The Splendid Table",
-      "longDescription": "The Splendid Table has been celebrating the intersection of food and life for more than two decades. A culinary, culture and lifestyle program, it has hosted our nation's conversations about cooking, sustainability and food culture and has introduced us to generations of food dignitaries.\n\nRecently, Francis Lam was named host of the show. A regular contributor and frequent guest host on The Splendid Table since 2010, Lam is the former Eat columnist for The New York Times Magazine and is Editor-at-Large at Clarkson Potter, a division within Penguin Random House that is a leader in cookbook publishing. In his tenure at Clarkson Potter, he has been the editor behind some of the most creative and best-selling cookbooks and has worked with acclaimed authors, some of the country's hottest restaurateurs and chefs, as well as celebrities Chrissy Teigen and Questlove. For two seasons, Lam was a regular judge on Bravo's hit show, Top Chef Masters, a spinoff of Top Chef, where world-renowned chefs competed against each other in weekly challenges.\n\nThe show has been listed on numerous \"best of\" podcast lists including a recent nod by the Huffington Post's Food Editor as the top food podcast...",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/c1f72b2068d545ef5c24dd7367dc49bb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "4b9b1a33-6ce7-4602-8e4f-d14b4f33a358",
-      "description": "",
-      "name": "This American Live",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "b604081d-5220-4092-9fec-20c90981652b",
-      "description": "",
-      "name": "Throughline",
-      "longDescription": "",
-      "images": [
-        {
-          "url": "",
-          "type": "largerectangleimage",
-          "width": 1280,
-          "height": 800
-        },
-        {
-          "url": "",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        },
-        {
-          "url": "",
-          "type": "largesquareimage",
-          "width": 1280,
-          "height": 1280
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
-      "description": "",
-      "name": "Wait Wait... Don't Tell Me!",
-      "longDescription": "For a wacky and whip-smart approach to the week's news and newsmakers, listen no further than Wait Wait...Don't Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week's events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "a247770a-afbd-4d8f-88df-7a5594f93177",
-      "description": "",
-      "name": "Weekend Edition Saturday",
-      "longDescription": "NPR's two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/658ac7f45bfda071fd7b440d20816bdb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    },
-    {
-      "id": "0762826a-5320-4e2d-94f3-b37de4acbd7f",
-      "description": "",
-      "name": "Weekend Edition Sunday",
-      "longDescription": "NPR's two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
-      "images": [
-        {
-          "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-demo/019a79b328277d27bb6ca6abffcacdbf/658ac7f45bfda071fd7b440d20816bdb.jpg",
-          "type": "imagepath",
-          "width": 600,
-          "height": 600
-        }
-      ],
-      "presenterIds": []
-    }
-  ],
-  "presenters": []
+    "episodes": [
+        {
+            "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20260218",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-19T00:00:00Z",
+            "endTime": "2026-02-19T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20260218",
+            "name": "On Point from APM",
+            "description": "",
+            "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
+            "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
+            "startTime": "2026-02-19T01:00:00Z",
+            "endTime": "2026-02-19T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/18f34f42da9c91ba3a527f14c3344df8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d5c7845d-eace-4600-bddd-b145a7a80d13_20260218",
+            "name": "The Moth",
+            "description": "",
+            "longDescription": "",
+            "showId": "7eb0b8f4-7326-4455-80d1-2b6836464488",
+            "startTime": "2026-02-19T02:00:00Z",
+            "endTime": "2026-02-19T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "10ad363d-a493-4468-b12e-45091fa0b872_20260218",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "startTime": "2026-02-19T03:00:00Z",
+            "endTime": "2026-02-19T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260218",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-19T04:00:00Z",
+            "endTime": "2026-02-19T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20260219",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-19T05:00:00Z",
+            "endTime": "2026-02-19T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20260219",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-19T10:00:00Z",
+            "endTime": "2026-02-19T11:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20260219",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-19T12:00:00Z",
+            "endTime": "2026-02-19T13:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20260219",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-19T14:00:00Z",
+            "endTime": "2026-02-19T14:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20260219",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "",
+            "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "startTime": "2026-02-19T14:59:00Z",
+            "endTime": "2026-02-19T16:59:00Z",
+            "duration": "02:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20260219",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "",
+            "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "startTime": "2026-02-19T17:00:00Z",
+            "endTime": "2026-02-19T18:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20260219",
+            "name": "Fresh Air with Terry Gross",
+            "description": "",
+            "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry\u0027s fascinating interviews and features, Fresh Air\u0027s stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
+            "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
+            "startTime": "2026-02-19T19:00:00Z",
+            "endTime": "2026-02-19T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20260219",
+            "name": "1A",
+            "description": "",
+            "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together \u2014 welcome to 1A.  \n\nThe conversation isn\u2019t just on air. 1A invites you to join in. We\u2019ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
+            "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
+            "startTime": "2026-02-19T20:00:00Z",
+            "endTime": "2026-02-19T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/54e56aea89ed148ba682892ba20680c8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20260219",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-19T21:00:00Z",
+            "endTime": "2026-02-19T23:30:00Z",
+            "duration": "02:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20260219",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "startTime": "2026-02-19T23:30:00Z",
+            "endTime": "2026-02-20T00:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20260219",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-20T00:00:00Z",
+            "endTime": "2026-02-20T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "019c6d40-bfad-7ef0-9fd9-eea21c5ae2b1_20260219",
+            "name": "Theater of War: ICE in Our Schools",
+            "description": "",
+            "longDescription": "",
+            "showId": "019c6d40-b695-7f08-a093-5ee195662fa6",
+            "startTime": "2026-02-20T01:00:00Z",
+            "endTime": "2026-02-20T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "019c6d56-d569-721b-b745-3c9f1ce72ced_20260219",
+            "name": "Storytellers: Muslims, Community, and Culture in America",
+            "description": "",
+            "longDescription": "There has been considerable attention paid to American Muslims in the 25 years since 9/11. But largely missing are people from the community telling compelling and authentic stories about their history and their own lived experiences. Comedian and host Sabeen Sadiq introduces listeners to engaging Muslim American storytellers, starting with Sadiq\u2019s own honest and very funny story about growing up a sort of \u201Csecret Muslim\u201D in Chicago. Listeners will be captivated and moved by these stories, which reveal the complexity and deep roots of vibrant Muslim communities in America.",
+            "showId": "019b2352-757a-71bd-a822-b2a846d1386f",
+            "startTime": "2026-02-20T02:00:00Z",
+            "endTime": "2026-02-20T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/a8ed7a694061e9fee2720b00c52a87e9.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "10ad363d-a493-4468-b12e-45091fa0b872_20260219",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "startTime": "2026-02-20T03:00:00Z",
+            "endTime": "2026-02-20T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260219",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-20T04:00:00Z",
+            "endTime": "2026-02-20T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20260220",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-20T05:00:00Z",
+            "endTime": "2026-02-20T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20260220",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-20T10:00:00Z",
+            "endTime": "2026-02-20T11:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20260220",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-20T12:00:00Z",
+            "endTime": "2026-02-20T13:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20260220",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-20T14:00:00Z",
+            "endTime": "2026-02-20T14:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20260220",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "As Goes Texas?; Mamdani\u0027s Budget and Tax Hike Proposals; \u0027Theater Of War\u0027 on ICE \u0026 Minneapolis; \u0027The Alabama Solution\u0027",
+            "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "startTime": "2026-02-20T14:59:00Z",
+            "endTime": "2026-02-20T16:59:00Z",
+            "duration": "02:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20260220",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "Raphael Saadiq\u0027s Oscar Nom\u0027d Song From \u0027Sinners\u0027; Doc About \u00275th Beatle\u0027 Billy Preston; August Ponthier\u0027s Debut Album; New Play About Marcel Marceau In WWII",
+            "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "startTime": "2026-02-20T17:00:00Z",
+            "endTime": "2026-02-20T18:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "5b575c76-bfcc-4acb-bb3e-c2f85f8b67df_20260220",
+            "name": "Science Friday Hour 1",
+            "description": "",
+            "longDescription": "Hour 1:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
+            "showId": "a4d7b6c6-63ee-4d7a-9861-85dfe951fab2",
+            "startTime": "2026-02-20T19:00:00Z",
+            "endTime": "2026-02-20T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4e20aba1-2d6b-482d-8ca8-f4f964e5f4ed_20260220",
+            "name": "Science Friday Hour 2",
+            "description": "",
+            "longDescription": "Hour 2:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
+            "showId": "92250676-a072-497e-8ff9-354fca52daa1",
+            "startTime": "2026-02-20T20:00:00Z",
+            "endTime": "2026-02-20T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20260220",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-20T21:00:00Z",
+            "endTime": "2026-02-20T23:30:00Z",
+            "duration": "02:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20260220",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "startTime": "2026-02-20T23:30:00Z",
+            "endTime": "2026-02-21T00:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20260220",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-21T00:00:00Z",
+            "endTime": "2026-02-21T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20260220",
+            "name": "On Point from APM",
+            "description": "",
+            "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
+            "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
+            "startTime": "2026-02-21T01:00:00Z",
+            "endTime": "2026-02-21T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/18f34f42da9c91ba3a527f14c3344df8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "c7069dc9-b49f-47be-b01e-10d38181d97a_20260220",
+            "name": "On The Media",
+            "description": "",
+            "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
+            "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
+            "startTime": "2026-02-21T02:00:00Z",
+            "endTime": "2026-02-21T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/839c1936fdd317120deebb5a0cd630ec.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "10ad363d-a493-4468-b12e-45091fa0b872_20260220",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "startTime": "2026-02-21T03:00:00Z",
+            "endTime": "2026-02-21T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260220",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-21T04:00:00Z",
+            "endTime": "2026-02-21T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "e3c31d77-ddfe-4a08-9a72-298593a44456_20260221",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-21T05:00:00Z",
+            "endTime": "2026-02-21T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "a38b98da-9dac-41ce-9f0a-7069615e743b_20260221",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-21T10:00:00Z",
+            "endTime": "2026-02-21T10:29:00Z",
+            "duration": "00:29:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6049170d-8fd2-42db-89b0-191711994ea7_20260221",
+            "name": "The Capitol Connection",
+            "description": "",
+            "longDescription": "",
+            "showId": "4ca6af26-1207-49f5-b244-539538595c11",
+            "startTime": "2026-02-21T10:30:00Z",
+            "endTime": "2026-02-21T11:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "858bebbe-046c-4cfe-b15f-8f8aa3d30e76_20260221",
+            "name": "The Pulse",
+            "description": "",
+            "longDescription": "",
+            "showId": "0fd1be5c-9e07-4d7c-ba3c-7b108cf48ce5",
+            "startTime": "2026-02-21T11:00:00Z",
+            "endTime": "2026-02-21T12:00:00Z",
+            "duration": "01:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d9db694b-1589-4eb2-b531-4c634c8a2597_20260221",
+            "name": "On The Media",
+            "description": "",
+            "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
+            "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
+            "startTime": "2026-02-21T12:00:00Z",
+            "endTime": "2026-02-21T12:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/839c1936fdd317120deebb5a0cd630ec.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9728a227-6a82-476b-9bba-d91c5cdef7ac_20260221",
+            "name": "Weekend Edition Saturday",
+            "description": "",
+            "longDescription": "NPR\u0027s two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
+            "showId": "a247770a-afbd-4d8f-88df-7a5594f93177",
+            "startTime": "2026-02-21T13:00:00Z",
+            "endTime": "2026-02-21T14:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/658ac7f45bfda071fd7b440d20816bdb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "a65f03b9-697c-437a-aff6-c786e8d8ffa2_20260221",
+            "name": "The New Yorker Radio Hour",
+            "description": "",
+            "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine\u2019s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine\u2019s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
+            "showId": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
+            "startTime": "2026-02-21T15:00:00Z",
+            "endTime": "2026-02-21T15:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/9a96007e3fd1468573a640ca4301437b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9e2e2644-fb5e-4d7f-8a31-5f293dd57c4d_20260221",
+            "name": "Wait Wait... Don\u0027t Tell Me!",
+            "description": "",
+            "longDescription": "For a wacky and whip-smart approach to the week\u0027s news and newsmakers, listen no further than Wait Wait...Don\u0027t Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week\u0027s events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
+            "showId": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
+            "startTime": "2026-02-21T16:00:00Z",
+            "endTime": "2026-02-21T16:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4b14521d-f99f-4157-8809-2313074d1fce_20260221",
+            "name": "Radiolab",
+            "description": "",
+            "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It\u0027s Technicolor radio. Radiolab is produced and distributed by WNYC.",
+            "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
+            "startTime": "2026-02-21T17:00:00Z",
+            "endTime": "2026-02-21T17:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/85374fff377cc8b938f797c3c22f5afe.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "925a88aa-8ae6-4bdc-8d5d-79fb61ea4ae4_20260221",
+            "name": "Snap Judgement",
+            "description": "",
+            "longDescription": "",
+            "showId": "bf196f81-70c5-485e-b90d-f82a0ebcfc74",
+            "startTime": "2026-02-21T18:00:00Z",
+            "endTime": "2026-02-21T18:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "30f3b776-45d4-4478-abf7-ce01fe235dbd_20260221",
+            "name": "It\u0027s Been a Minute",
+            "description": "",
+            "longDescription": "",
+            "showId": "85557c4e-00dc-4b6a-9856-0c6de5d2ac96",
+            "startTime": "2026-02-21T19:00:00Z",
+            "endTime": "2026-02-21T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "7c9ae210-5711-40ad-9803-fd24341ead6c_20260221",
+            "name": "Planet Money and How I Built This",
+            "description": "",
+            "longDescription": "Planet Money explains the economy with playful storytelling and Peabody award-winning deep dive, roll up your sleeves journalism. The team includes Adrian Ma, Mary Childs, Amanda Aronczyk, Jeff Guo, Nick Fountain, Erika Beras, Sarah Gonzalez, Robert Smith and Kenny Malone.\n\nGuy Raz hosts How I Built This, where innovators, entrepreneurs, and idealists take us through the often challenging journeys they took to build their now iconic companies. Featured guests include the founders of Lyft, Patagonia, Zappos, Spanx, Samuel Adams, Instagram, and more",
+            "showId": "aaf6bcf3-efca-4069-8b31-bc11e6262f16",
+            "startTime": "2026-02-21T20:00:00Z",
+            "endTime": "2026-02-21T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/dbfe72c6680bf8c47f316dff13cd568f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "707e9d18-c35e-4151-a748-dacadede8d12_20260221",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-21T21:00:00Z",
+            "endTime": "2026-02-21T21:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6a487302-b7a8-4783-93de-1e62e8f51626_20260221",
+            "name": "All Things Considered Weekend",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
+            "startTime": "2026-02-21T22:00:00Z",
+            "endTime": "2026-02-21T22:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "2eb26a0c-8248-4dc5-a531-4200cd7a2189_20260221",
+            "name": "Open to Debate",
+            "description": "",
+            "longDescription": "America is more divided than ever\u2014but it doesn\u2019t have to be. Open to Debate offers an antidote to the chaos. We bring multiple perspectives together for real debates. Debates that are structured, respectful, clever, provocative, and driven by the facts. Open to Debate is on a mission to restore balance to the public square through expert moderation, good-faith arguments, and reasoned analysis. We examine the issues of the day with the world\u2019s most influential thinkers spanning science, technology, politics, culture, and global affairs. It\u2019s time to build a stronger, more united democracy with the civil exchange of ideas. Be open-minded. Be curious. Be ready to listen. Join us in being Open to Debate.",
+            "showId": "6e625ebf-d7e7-4c1b-a8c6-9567b55ef0ea",
+            "startTime": "2026-02-21T23:00:00Z",
+            "endTime": "2026-02-21T23:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/f8c10241898580805b224da5429c4b78.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "c4f10397-09f8-4743-a412-88be9648f2a9_20260221",
+            "name": "Fresh Air Weekend",
+            "description": "",
+            "longDescription": "Look to Fresh Air Weekend for highlights of some of the best interviews and reviews from past weeks, and new program elements specially paced for weekends. Fresh Air Weekend emphasizes interviews with writers, filmmakers, actors, and musicians, and often includes excerpts from live in-studio concerts. Many of the most popular reviewers from weekday Fresh Air can also be heard on Fresh Air Weekend sharing insights into recent movies, music, and books. And there\u0027s more. Special segments, including reviews of recently released videos, have been added to the program for additional weekend appeal.\n\nFresh Air Weekend is everything you already love about Fresh Air -- tailored for Saturday and Sunday.",
+            "showId": "d57e1486-0e22-40b6-beac-2afd890d2ee2",
+            "startTime": "2026-02-22T00:00:00Z",
+            "endTime": "2026-02-22T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "939bb17d-b315-4f90-81c4-1bed18780103_20260221",
+            "name": "Latino USA",
+            "description": "",
+            "longDescription": "",
+            "showId": "1a287c7c-af21-4221-8597-6a205a59b283",
+            "startTime": "2026-02-22T01:00:00Z",
+            "endTime": "2026-02-22T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "68580d5e-38e7-4941-bbd6-af95b7fe4323_20260221",
+            "name": "Bullseye with Jesse Thorn",
+            "description": "",
+            "longDescription": "",
+            "showId": "06af8775-f2c6-436c-96aa-bc45796df19d",
+            "startTime": "2026-02-22T02:00:00Z",
+            "endTime": "2026-02-22T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "a484dae9-494b-41e0-bf8d-8e0bf44323fd_20260221",
+            "name": "Live Wire with Luke Burbank",
+            "description": "",
+            "longDescription": "",
+            "showId": "288f67ce-4c74-438a-a5ac-6e57b77a8b58",
+            "startTime": "2026-02-22T03:00:00Z",
+            "endTime": "2026-02-22T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260221",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-22T04:00:00Z",
+            "endTime": "2026-02-22T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "f364f5ff-7386-44db-a185-4d79a371600a_20260222",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-22T05:00:00Z",
+            "endTime": "2026-02-22T11:00:00Z",
+            "duration": "06:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "87826193-0ce0-43cb-a725-833b8e961872_20260222",
+            "name": "The Splendid Table",
+            "description": "",
+            "longDescription": "The Splendid Table has been celebrating the intersection of food and life for more than two decades. A culinary, culture and lifestyle program, it has hosted our nation\u0027s conversations about cooking, sustainability and food culture and has introduced us to generations of food dignitaries.\n\nRecently, Francis Lam was named host of the show. A regular contributor and frequent guest host on The Splendid Table since 2010, Lam is the former Eat columnist for The New York Times Magazine and is Editor-at-Large at Clarkson Potter, a division within Penguin Random House that is a leader in cookbook publishing. In his tenure at Clarkson Potter, he has been the editor behind some of the most creative and best-selling cookbooks and has worked with acclaimed authors, some of the country\u0027s hottest restaurateurs and chefs, as well as celebrities Chrissy Teigen and Questlove. For two seasons, Lam was a regular judge on Bravo\u0027s hit show, Top Chef Masters, a spinoff of Top Chef, where world-renowned chefs competed against each other in weekly challenges.\n\nThe show has been listed on numerous \u0022best of\u0022 podcast lists including a recent nod by the Huffington Post\u0027s Food Editor as the top food podcast...",
+            "showId": "210f8cb2-1aa5-4f51-be53-841b667f49a1",
+            "startTime": "2026-02-22T11:00:00Z",
+            "endTime": "2026-02-22T12:00:00Z",
+            "duration": "01:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/c1f72b2068d545ef5c24dd7367dc49bb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "56bbd484-d280-49a8-8593-f408dd4f7fde_20260222",
+            "name": "The Capitol Pressroom",
+            "description": "",
+            "longDescription": "",
+            "showId": "faf058e8-0dbe-43ed-ad59-6a788594fe74",
+            "startTime": "2026-02-22T12:00:00Z",
+            "endTime": "2026-02-22T13:00:00Z",
+            "duration": "01:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "45ec041c-677d-43ed-be29-a619a4e39ccc_20260222",
+            "name": "Weekend Edition Sunday",
+            "description": "",
+            "longDescription": "NPR\u0027s two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
+            "showId": "0762826a-5320-4e2d-94f3-b37de4acbd7f",
+            "startTime": "2026-02-22T13:00:00Z",
+            "endTime": "2026-02-22T14:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/658ac7f45bfda071fd7b440d20816bdb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "26a06f24-6660-4588-afcb-13d920c33260_20260222",
+            "name": "On The Media",
+            "description": "",
+            "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
+            "showId": "0fad500e-1128-442c-89c7-ce6d851911ee",
+            "startTime": "2026-02-22T15:00:00Z",
+            "endTime": "2026-02-22T15:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/839c1936fdd317120deebb5a0cd630ec.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "1dbc5c18-c216-4ab1-baca-bc5c56c813b9_20260222",
+            "name": "Reveal",
+            "description": "",
+            "longDescription": "",
+            "showId": "947bc247-45a4-4257-aa9a-66d3881341a4",
+            "startTime": "2026-02-22T16:00:00Z",
+            "endTime": "2026-02-22T17:00:00Z",
+            "duration": "01:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "64cf3b77-c99a-48c1-9e17-2798d2b2914e_20260222",
+            "name": "This American Live",
+            "description": "",
+            "longDescription": "",
+            "showId": "4b9b1a33-6ce7-4602-8e4f-d14b4f33a358",
+            "startTime": "2026-02-22T17:00:00Z",
+            "endTime": "2026-02-22T17:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "e02c642a-a7cb-4de8-ad23-684a8606fa7a_20260222",
+            "name": "Freakonomics Radio",
+            "description": "",
+            "longDescription": "Freakonomics Radio ferrets out connections between seemingly unrelated things. The program explores the riddles of everyday life and the weird wrinkles of human nature\u2014 from cheating and crime to parenting and sports\u2014 using the tools of economics to explore real-world behavior. \n\nHost Stephen J. Dubner discovers the hidden side of everything in interviews with Nobel laureates and provocateurs, social scientists and entrepreneurs \u2014 and with his \u201CFreakonomics\u201D co-author Steve Levitt.",
+            "showId": "e966192a-df3b-42a4-b384-28ca0d0038f7",
+            "startTime": "2026-02-22T18:00:00Z",
+            "endTime": "2026-02-22T18:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/95873dda648006099ce427ea8dccc39f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "fc6db6d9-ee33-4a6e-ac6e-b7181a5e3967_20260222",
+            "name": "Wait Wait... Don\u0027t Tell Me!",
+            "description": "",
+            "longDescription": "For a wacky and whip-smart approach to the week\u0027s news and newsmakers, listen no further than Wait Wait...Don\u0027t Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week\u0027s events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
+            "showId": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
+            "startTime": "2026-02-22T19:00:00Z",
+            "endTime": "2026-02-22T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "ae79470a-a4ed-402e-bee6-baa22a2a1823_20260222",
+            "name": "The New Yorker Radio Hour",
+            "description": "",
+            "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine\u2019s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine\u2019s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
+            "showId": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
+            "startTime": "2026-02-22T20:00:00Z",
+            "endTime": "2026-02-22T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/9a96007e3fd1468573a640ca4301437b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8408f165-62f1-4052-b35e-e0dd0833b7ba_20260222",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-22T21:00:00Z",
+            "endTime": "2026-02-22T21:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6a487302-b7a8-4783-93de-1e62e8f51626_20260222",
+            "name": "All Things Considered Weekend",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
+            "startTime": "2026-02-22T22:00:00Z",
+            "endTime": "2026-02-22T22:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "5d37b8dc-cb4d-4c6f-94e3-c531adf21d49_20260222",
+            "name": "Radiolab",
+            "description": "",
+            "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It\u0027s Technicolor radio. Radiolab is produced and distributed by WNYC.",
+            "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
+            "startTime": "2026-02-22T23:00:00Z",
+            "endTime": "2026-02-22T23:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/85374fff377cc8b938f797c3c22f5afe.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "b63a81db-9f17-43ea-94ee-05d06a5f762c_20260222",
+            "name": "Throughline",
+            "description": "",
+            "longDescription": "",
+            "showId": "b604081d-5220-4092-9fec-20c90981652b",
+            "startTime": "2026-02-23T00:00:00Z",
+            "endTime": "2026-02-23T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "0c706d89-4d61-4851-9eb4-81f01f46cc63_20260222",
+            "name": "TED Radio Hour",
+            "description": "",
+            "longDescription": "TED Radio Hour investigates the biggest questions of our time with the help of the world\u2019s greatest thinkers. Can we preserve our humanity in the digital age? Where does creativity come from? And what\u0027s the secret to living longer? In each episode, host Manoush Zomorodi explores a big idea through a series of TED Talks and original interviews, inspiring us to learn more about the world, our communities, and most importantly, ourselves.",
+            "showId": "254604f0-77c5-4ff2-9ccf-6ad5e298adf8",
+            "startTime": "2026-02-23T01:00:00Z",
+            "endTime": "2026-02-23T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b54406a5366faa3f92802b50f9623e90.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9fd133c4-9c08-467a-8ed5-65b0d9fd51d2_20260222",
+            "name": "The Moth",
+            "description": "",
+            "longDescription": "",
+            "showId": "7eb0b8f4-7326-4455-80d1-2b6836464488",
+            "startTime": "2026-02-23T02:00:00Z",
+            "endTime": "2026-02-23T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "34a4da6e-47bf-4a97-8f26-97611d716a94_20260222",
+            "name": "Selected Shorts",
+            "description": "",
+            "longDescription": "Our greatest actors transport us through the magic of fiction, one short story at a time. Sometimes funny. Always moving. Selected Shorts is the weekly program that connects you to the world with a rich diversity of voices from literature, film, theater, and comedy. From Symphony Space.\n\n\u201COne of the finest evenings at the theatre.\u201D David Sedaris \n\nSelected Shorts presents some best-loved selections of classic and contemporary short fiction read by acclaimed actors and recorded live at Symphony Space in New York City. Stories are alternately funny, sad, moving, and exciting and make a perfect accompaniment to daily activities. Some of the finest artists of the American theater and screen come through the doors of Symphony Space in a typical season. It is from these recordings that the radio show is produced. For almost three decades, performances have featured works by contemporary greats; as well as the fresh, vivid and diverse works of a new generation of remarkable literary talents. Distinguished works by classic masters such as Edith Wharton, James Thurber, James Baldwin, Shirley Jackson and Edgar Allan Poe have been thrilling audiences for years.\n\nMore than 80 stories are...",
+            "showId": "136c8bd0-f2ce-4efd-87b3-399171c8288a",
+            "startTime": "2026-02-23T03:00:00Z",
+            "endTime": "2026-02-23T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b2ed4a01ed98b454116837ce551f2fe7.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260222",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-23T04:00:00Z",
+            "endTime": "2026-02-23T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20260223",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-23T05:00:00Z",
+            "endTime": "2026-02-23T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20260223",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-23T10:00:00Z",
+            "endTime": "2026-02-23T11:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20260223",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-23T12:00:00Z",
+            "endTime": "2026-02-23T13:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20260223",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-23T14:00:00Z",
+            "endTime": "2026-02-23T14:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20260223",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "The Epstein Files: Redactions and International Fallout; What to do About the Crumbling BQE; History of Black History Month: The Second 50 Years",
+            "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "startTime": "2026-02-23T14:59:00Z",
+            "endTime": "2026-02-23T16:59:00Z",
+            "duration": "02:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20260223",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "",
+            "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "startTime": "2026-02-23T17:00:00Z",
+            "endTime": "2026-02-23T18:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20260223",
+            "name": "Fresh Air with Terry Gross",
+            "description": "",
+            "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry\u0027s fascinating interviews and features, Fresh Air\u0027s stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
+            "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
+            "startTime": "2026-02-23T19:00:00Z",
+            "endTime": "2026-02-23T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20260223",
+            "name": "1A",
+            "description": "",
+            "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together \u2014 welcome to 1A.  \n\nThe conversation isn\u2019t just on air. 1A invites you to join in. We\u2019ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
+            "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
+            "startTime": "2026-02-23T20:00:00Z",
+            "endTime": "2026-02-23T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/54e56aea89ed148ba682892ba20680c8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20260223",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-23T21:00:00Z",
+            "endTime": "2026-02-23T23:30:00Z",
+            "duration": "02:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20260223",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "startTime": "2026-02-23T23:30:00Z",
+            "endTime": "2026-02-24T00:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20260223",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-24T00:00:00Z",
+            "endTime": "2026-02-24T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20260223",
+            "name": "On Point from APM",
+            "description": "",
+            "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
+            "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
+            "startTime": "2026-02-24T01:00:00Z",
+            "endTime": "2026-02-24T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/18f34f42da9c91ba3a527f14c3344df8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "30a3ab82-6938-44ac-acca-32b355bb11be_20260223",
+            "name": "Radiolab",
+            "description": "",
+            "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It\u0027s Technicolor radio. Radiolab is produced and distributed by WNYC.",
+            "showId": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
+            "startTime": "2026-02-24T02:00:00Z",
+            "endTime": "2026-02-24T02:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/85374fff377cc8b938f797c3c22f5afe.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "10ad363d-a493-4468-b12e-45091fa0b872_20260223",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "startTime": "2026-02-24T03:00:00Z",
+            "endTime": "2026-02-24T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260223",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-24T04:00:00Z",
+            "endTime": "2026-02-24T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20260224",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-24T05:00:00Z",
+            "endTime": "2026-02-24T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20260224",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-24T10:00:00Z",
+            "endTime": "2026-02-24T11:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20260224",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-24T12:00:00Z",
+            "endTime": "2026-02-24T13:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20260224",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-24T14:00:00Z",
+            "endTime": "2026-02-24T14:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20260224",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "",
+            "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "startTime": "2026-02-24T14:59:00Z",
+            "endTime": "2026-02-24T16:59:00Z",
+            "duration": "02:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20260224",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "Winter Olympics Check-In; Dumpling Delights For Lunar New Year; Urban Agriculture; Exploring Emotional (And Physical) Intimacy",
+            "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "startTime": "2026-02-24T17:00:00Z",
+            "endTime": "2026-02-24T18:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20260224",
+            "name": "Fresh Air with Terry Gross",
+            "description": "",
+            "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry\u0027s fascinating interviews and features, Fresh Air\u0027s stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
+            "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
+            "startTime": "2026-02-24T19:00:00Z",
+            "endTime": "2026-02-24T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20260224",
+            "name": "1A",
+            "description": "",
+            "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together \u2014 welcome to 1A.  \n\nThe conversation isn\u2019t just on air. 1A invites you to join in. We\u2019ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
+            "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
+            "startTime": "2026-02-24T20:00:00Z",
+            "endTime": "2026-02-24T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/54e56aea89ed148ba682892ba20680c8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20260224",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-24T21:00:00Z",
+            "endTime": "2026-02-24T23:30:00Z",
+            "duration": "02:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20260224",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "startTime": "2026-02-24T23:30:00Z",
+            "endTime": "2026-02-25T00:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "4afaea12-9dfb-4356-ab27-c0cb399d7199_20260224",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-25T00:00:00Z",
+            "endTime": "2026-02-25T00:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "92a5f8d3-faad-47f3-aa8b-5d5e870363e3_20260224",
+            "name": "On Point from APM",
+            "description": "",
+            "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
+            "showId": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
+            "startTime": "2026-02-25T01:00:00Z",
+            "endTime": "2026-02-25T01:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/18f34f42da9c91ba3a527f14c3344df8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "20e7611b-aacc-4919-bfd0-e9fc280e673f_20260224",
+            "name": "Reveal",
+            "description": "",
+            "longDescription": "",
+            "showId": "947bc247-45a4-4257-aa9a-66d3881341a4",
+            "startTime": "2026-02-25T02:00:00Z",
+            "endTime": "2026-02-25T03:00:00Z",
+            "duration": "01:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "10ad363d-a493-4468-b12e-45091fa0b872_20260224",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "showId": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "startTime": "2026-02-25T03:00:00Z",
+            "endTime": "2026-02-25T03:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "9d5af867-49e2-4c8f-a2ea-21601ef941bf_20260224",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "showId": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "startTime": "2026-02-25T04:00:00Z",
+            "endTime": "2026-02-25T04:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "8db42a33-bcee-48d7-92a4-6acbb6f3f879_20260225",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-25T05:00:00Z",
+            "endTime": "2026-02-25T10:00:00Z",
+            "duration": "05:00:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "1d45bf11-4377-4a2f-8054-84875d939fe3_20260225",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-25T10:00:00Z",
+            "endTime": "2026-02-25T11:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "af238b8b-cfc3-4ed5-98b4-a6c17ec0ed35_20260225",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "showId": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "startTime": "2026-02-25T12:00:00Z",
+            "endTime": "2026-02-25T13:50:00Z",
+            "duration": "01:50:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "6325f786-3b09-4eb7-a70b-2ead7b87a87a_20260225",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "showId": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "startTime": "2026-02-25T14:00:00Z",
+            "endTime": "2026-02-25T14:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "b1c32c70-974e-415c-a6c6-e424ebf7de92_20260225",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "Sen. Andy Kim; GLP-1s and Addiction; California\u0027s Proposed Billionaire Tax; \u0027The Perfect Neighbor\u0027",
+            "showId": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "startTime": "2026-02-25T14:59:00Z",
+            "endTime": "2026-02-25T16:59:00Z",
+            "duration": "02:00:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "9b9349e5-e438-4a72-90a0-55d4df8eaf8f_20260225",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "Journal of Prompts From \u0027The Moth\u0027; The Medical Science Of The \u0027Winter Blues\u0027; Emily Dickinson\u0027s Poetry For Voice And Strings; The Costumes Of \u0027Frankenstein\u0027",
+            "showId": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "startTime": "2026-02-25T17:00:00Z",
+            "endTime": "2026-02-25T18:59:00Z",
+            "duration": "01:59:00",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": true
+        },
+        {
+            "id": "df51475c-b9e9-4955-81a2-2853909af5a7_20260225",
+            "name": "Fresh Air with Terry Gross",
+            "description": "",
+            "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry\u0027s fascinating interviews and features, Fresh Air\u0027s stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
+            "showId": "4dd97838-74ac-4467-bd73-859b06040d4f",
+            "startTime": "2026-02-25T19:00:00Z",
+            "endTime": "2026-02-25T19:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "0cbf73ef-6346-497d-a6a2-39b837b568b7_20260225",
+            "name": "1A",
+            "description": "",
+            "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together \u2014 welcome to 1A.  \n\nThe conversation isn\u2019t just on air. 1A invites you to join in. We\u2019ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
+            "showId": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
+            "startTime": "2026-02-25T20:00:00Z",
+            "endTime": "2026-02-25T20:59:00Z",
+            "duration": "00:59:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/54e56aea89ed148ba682892ba20680c8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "d2ee867b-4201-4c74-a1f5-f6fc2d8ebd22_20260225",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "showId": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "startTime": "2026-02-25T21:00:00Z",
+            "endTime": "2026-02-25T23:30:00Z",
+            "duration": "02:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        },
+        {
+            "id": "ebabe244-51d7-41dc-8701-6a074f45ed1f_20260225",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "showId": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "startTime": "2026-02-25T23:30:00Z",
+            "endTime": "2026-02-26T00:00:00Z",
+            "duration": "00:30:00",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": [],
+            "temporaryChanges": false
+        }
+    ],
+    "shows": [
+        {
+            "id": "cf6d7965-e73c-4f4d-bd62-06b5b6e8c4d7",
+            "name": "1A",
+            "description": "",
+            "longDescription": "Listening to the news can feel like a journey. 1A guides you beyond the headlines - explaining complicated issues and cutting through the noise - while bringing together thoughtful guests and listeners from around the country. Fridays are home to our news roundups, where we answer your questions about the biggest stories of the week. Celebrate your freedom to listen by getting to the heart of the story, together \u2014 welcome to 1A.  \n\nThe conversation isn\u2019t just on air. 1A invites you to join in. We\u2019ll regularly post questions and requests for feedback on this page. And you can talk to us on Twitter, Facebook, or by texting 1A to 1-844-777-7050.\n\n1A is produced by WAMU 88.5, and distributed by NPR.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/54e56aea89ed148ba682892ba20680c8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "798fc143-0fca-4200-8797-cb6ac566be13",
+            "name": "All Of It",
+            "description": "",
+            "longDescription": "Raphael Saadiq\u0027s Oscar Nom\u0027d Song From \u0027Sinners\u0027; Doc About \u00275th Beatle\u0027 Billy Preston; August Ponthier\u0027s Debut Album; New Play About Marcel Marceau In WWII",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "3a025731-f18a-4dac-ac03-746da53cf2e2",
+            "name": "All Things Considered",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "e2f151cd-3ba0-4cfc-9e77-85a20e7b96c3",
+            "name": "All Things Considered Weekend",
+            "description": "",
+            "longDescription": "NPR\u0027s afternoon radio newsmagazine presenting two hours of breaking news mixed with compelling analysis, insightful commentaries, interviews, and special - sometimes quirky - features. A one-hour edition of the program is available on Saturday and Sunday.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/32ed91573acc9d96b395e378866b158f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "42c878a9-fcd9-4c0e-b7ee-9294a21515d1",
+            "name": "BBC (APM) World Service",
+            "description": "",
+            "longDescription": "With over 60 bureaus worldwide, and journalists in more places than any other international broadcaster, audiences count on the BBC World Service to provide accurate, impartial and accessible news with a global perspective. Each week, nearly 8 million U.S. public radio listeners tune in to hear programming from BBC World Service.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/01809b98a2c2a7552a96e6076d00c179.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "06af8775-f2c6-436c-96aa-bc45796df19d",
+            "name": "Bullseye with Jesse Thorn",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "e966192a-df3b-42a4-b384-28ca0d0038f7",
+            "name": "Freakonomics Radio",
+            "description": "",
+            "longDescription": "Freakonomics Radio ferrets out connections between seemingly unrelated things. The program explores the riddles of everyday life and the weird wrinkles of human nature\u2014 from cheating and crime to parenting and sports\u2014 using the tools of economics to explore real-world behavior. \n\nHost Stephen J. Dubner discovers the hidden side of everything in interviews with Nobel laureates and provocateurs, social scientists and entrepreneurs \u2014 and with his \u201CFreakonomics\u201D co-author Steve Levitt.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/95873dda648006099ce427ea8dccc39f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "d57e1486-0e22-40b6-beac-2afd890d2ee2",
+            "name": "Fresh Air Weekend",
+            "description": "",
+            "longDescription": "Look to Fresh Air Weekend for highlights of some of the best interviews and reviews from past weeks, and new program elements specially paced for weekends. Fresh Air Weekend emphasizes interviews with writers, filmmakers, actors, and musicians, and often includes excerpts from live in-studio concerts. Many of the most popular reviewers from weekday Fresh Air can also be heard on Fresh Air Weekend sharing insights into recent movies, music, and books. And there\u0027s more. Special segments, including reviews of recently released videos, have been added to the program for additional weekend appeal.\n\nFresh Air Weekend is everything you already love about Fresh Air -- tailored for Saturday and Sunday.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "4dd97838-74ac-4467-bd73-859b06040d4f",
+            "name": "Fresh Air with Terry Gross",
+            "description": "",
+            "longDescription": "Fresh Air opens the window on contemporary arts and issues with guests from worlds as diverse as literature and economics. Terry Gross hosts this multi-award-winning daily interview and features program. The veteran public radio interviewer is known for her extraordinary ability to engage guests of all dispositions. Every weekday she delights intelligent and curious listeners with revelations on contemporary societal concerns. \n\nIn addition to Terry\u0027s fascinating interviews and features, Fresh Air\u0027s stellar roster of contributors includes interview contributor and fill-in host Dave Davies, who is also Senior Reporter for WHYY; classical music critic Lloyd Schwartz, who teaches in the Creative Writing MFA program at the University of Massachusetts, Boston; language commentator Geoffrey Nunberg, a linguist who teaches at the University of California, Berkeley, School of Information; rock critic Ken Tucker, who is critic at large for Yahoo TV; book critic Maureen Corrigan, who teaches literature at Georgetown University and is the author of the book So We Read On: How the Great Gatsby Came to Be and Why it Endures; television critic David Bianculli, founder and editor of the websit...",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/79b10329f3d91babd250b9dcdd82c274.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "85557c4e-00dc-4b6a-9856-0c6de5d2ac96",
+            "name": "It\u0027s Been a Minute",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "1a287c7c-af21-4221-8597-6a205a59b283",
+            "name": "Latino USA",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "288f67ce-4c74-438a-a5ac-6e57b77a8b58",
+            "name": "Live Wire with Luke Burbank",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "79dfceb2-f583-4a62-98bd-578a7d5d53fc",
+            "name": "Marketplace",
+            "description": "",
+            "longDescription": "Hosted by Kai Ryssdal, Marketplace is the leading business news radio program that provides context on the economic news of the day. Through stories, conversations and newsworthy developments, we help listeners understand the economic world around them.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/e32b012dd07cddc0c9f66b80d0f64804.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "14cb2422-825d-4ff5-9b82-8f71a312630c",
+            "name": "Morning Edition",
+            "description": "",
+            "longDescription": "NPR\u0027s weekday morning newsmagazine providing news in context, airing thoughtful ideas and commentary, and reviewing important new music, books, and events in the arts.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/1e823436f4b4348b491b13e28ccb4c40.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "6d06216f-0819-4d14-929c-8c26a14e5eda",
+            "name": "New Sounds",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "54a4b17d-5dca-4bea-9f6a-b181bf61001e",
+            "name": "On Point from APM",
+            "description": "",
+            "longDescription": "On Point unites distinct and provocative voices with passionate discussion as it confronts the stories that are at the center of what is important in the world today. Leaving no perspective unchallenged, On Point digs past the surface and into the core of a subject, exposing each of its real world implications. Each broadcast is an in-depth conversation decoding a single topic with newsmakers, thinkers, and callers, and closes with compelling personal reactions to news and important issues, including radio diaries, excerpts from speeches, or special series segments.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/18f34f42da9c91ba3a527f14c3344df8.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "0fad500e-1128-442c-89c7-ce6d851911ee",
+            "name": "On The Media",
+            "description": "",
+            "longDescription": "While maintaining the civility and fairness that are the hallmarks of public radio, On The Media tackles sticky issues with a frankness and transparency that has built trust with listeners and an audience of more than one million people a week.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/839c1936fdd317120deebb5a0cd630ec.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "6e625ebf-d7e7-4c1b-a8c6-9567b55ef0ea",
+            "name": "Open to Debate",
+            "description": "",
+            "longDescription": "America is more divided than ever\u2014but it doesn\u2019t have to be. Open to Debate offers an antidote to the chaos. We bring multiple perspectives together for real debates. Debates that are structured, respectful, clever, provocative, and driven by the facts. Open to Debate is on a mission to restore balance to the public square through expert moderation, good-faith arguments, and reasoned analysis. We examine the issues of the day with the world\u2019s most influential thinkers spanning science, technology, politics, culture, and global affairs. It\u2019s time to build a stronger, more united democracy with the civil exchange of ideas. Be open-minded. Be curious. Be ready to listen. Join us in being Open to Debate.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/f8c10241898580805b224da5429c4b78.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "aaf6bcf3-efca-4069-8b31-bc11e6262f16",
+            "name": "Planet Money and How I Built This",
+            "description": "",
+            "longDescription": "Planet Money explains the economy with playful storytelling and Peabody award-winning deep dive, roll up your sleeves journalism. The team includes Adrian Ma, Mary Childs, Amanda Aronczyk, Jeff Guo, Nick Fountain, Erika Beras, Sarah Gonzalez, Robert Smith and Kenny Malone.\n\nGuy Raz hosts How I Built This, where innovators, entrepreneurs, and idealists take us through the often challenging journeys they took to build their now iconic companies. Featured guests include the founders of Lyft, Patagonia, Zappos, Spanx, Samuel Adams, Instagram, and more",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/dbfe72c6680bf8c47f316dff13cd568f.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "c95115af-7902-4cdc-ac24-861e62cf0ff1",
+            "name": "q from the CBC ",
+            "description": "",
+            "longDescription": "\u0022q\u0022 is a lively arts, culture and entertainment magazine. It\u0027s a smart and surprising tour through personalities and cultural issues that matter. \n\n\u0022q\u0022 covers pop culture and high arts with forays into the most provocative and compelling cultural trends. With wide-ranging guests \u2014 Bonnie Raitt, Matthew  McConaughey, k.d. lang and more \u2014 the program explores such provocative topics as the branding of politicians or whether \u0022cougar\u0022 should be embraced or discarded by older women. \u0022q\u0022 presents big names, big ideas and those paving the way in the cultural community. \n\n\u0022q\u0022 \u2014 a cultural intervention!",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/7e63555d96b9802d8687d08a68cadc7b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "ec8f92a9-d704-4f75-ae77-0ded0fd2bd2d",
+            "name": "Radiolab",
+            "description": "",
+            "longDescription": "Each hour we take a big idea, so big that it lives everywhere, hiding in a thousand places under different names, and we chase that idea, going wherever whim takes us. Along the way, hosts Jad Abumrad and Robert Krulwich interview, argue, imagine, and discover the hidden connections that make this idea so surprisingly powerful. And the sounds you hear are as new and startling as the ideas we explore. It\u0027s Technicolor radio. Radiolab is produced and distributed by WNYC.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/85374fff377cc8b938f797c3c22f5afe.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "947bc247-45a4-4257-aa9a-66d3881341a4",
+            "name": "Reveal",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "a4d7b6c6-63ee-4d7a-9861-85dfe951fab2",
+            "name": "Science Friday Hour 1",
+            "description": "",
+            "longDescription": "Hour 1:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "92250676-a072-497e-8ff9-354fca52daa1",
+            "name": "Science Friday Hour 2",
+            "description": "",
+            "longDescription": "Hour 2:2. Each Friday, journalist Ira Flatow is joined by listeners and studio guests to explore science-related topics - subatomic particles, the human genome, the internet, earthquakes. Flatow offers in-depth discussion with scientists and others, giving listeners the chance to hear from the people whose work influences their daily lives.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/ce9fd9a66e27b467f2b63987825e9b5b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "136c8bd0-f2ce-4efd-87b3-399171c8288a",
+            "name": "Selected Shorts",
+            "description": "",
+            "longDescription": "Our greatest actors transport us through the magic of fiction, one short story at a time. Sometimes funny. Always moving. Selected Shorts is the weekly program that connects you to the world with a rich diversity of voices from literature, film, theater, and comedy. From Symphony Space.\n\n\u201COne of the finest evenings at the theatre.\u201D David Sedaris \n\nSelected Shorts presents some best-loved selections of classic and contemporary short fiction read by acclaimed actors and recorded live at Symphony Space in New York City. Stories are alternately funny, sad, moving, and exciting and make a perfect accompaniment to daily activities. Some of the finest artists of the American theater and screen come through the doors of Symphony Space in a typical season. It is from these recordings that the radio show is produced. For almost three decades, performances have featured works by contemporary greats; as well as the fresh, vivid and diverse works of a new generation of remarkable literary talents. Distinguished works by classic masters such as Edith Wharton, James Thurber, James Baldwin, Shirley Jackson and Edgar Allan Poe have been thrilling audiences for years.\n\nMore than 80 stories are...",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b2ed4a01ed98b454116837ce551f2fe7.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "bf196f81-70c5-485e-b90d-f82a0ebcfc74",
+            "name": "Snap Judgement",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "019b2352-757a-71bd-a822-b2a846d1386f",
+            "name": "Storytellers: Muslims, Community, and Culture in America",
+            "description": "",
+            "longDescription": "There has been considerable attention paid to American Muslims in the 25 years since 9/11. But largely missing are people from the community telling compelling and authentic stories about their history and their own lived experiences. Comedian and host Sabeen Sadiq introduces listeners to engaging Muslim American storytellers, starting with Sadiq\u2019s own honest and very funny story about growing up a sort of \u201Csecret Muslim\u201D in Chicago. Listeners will be captivated and moved by these stories, which reveal the complexity and deep roots of vibrant Muslim communities in America.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/a8ed7a694061e9fee2720b00c52a87e9.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "254604f0-77c5-4ff2-9ccf-6ad5e298adf8",
+            "name": "TED Radio Hour",
+            "description": "",
+            "longDescription": "TED Radio Hour investigates the biggest questions of our time with the help of the world\u2019s greatest thinkers. Can we preserve our humanity in the digital age? Where does creativity come from? And what\u0027s the secret to living longer? In each episode, host Manoush Zomorodi explores a big idea through a series of TED Talks and original interviews, inspiring us to learn more about the world, our communities, and most importantly, ourselves.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b54406a5366faa3f92802b50f9623e90.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "a9ca6c21-f3fd-4366-8ca9-f43349a45729",
+            "name": "The Brian Lehrer Show",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/aa0db0e7a95ca44cf02419ecad32805c.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "4ca6af26-1207-49f5-b244-539538595c11",
+            "name": "The Capitol Connection",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "faf058e8-0dbe-43ed-ad59-6a788594fe74",
+            "name": "The Capitol Pressroom",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "7eb0b8f4-7326-4455-80d1-2b6836464488",
+            "name": "The Moth",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "f88e59d6-9fa7-48da-acf2-ce3641fc63d3",
+            "name": "The New Yorker Radio Hour",
+            "description": "",
+            "longDescription": "The New Yorker Radio Hour is the program you will look forward to curling up with every weekend. \n\nDavid Remnick, the editor of The New Yorker, is joined by the magazine\u2019s award-winning writers in a weekly hour of radio that will both delight and inform. The New Yorker Radio Hour will feature a mix of profiles, storytelling, and insightful conversations about the issues that matter, plus an occasional blast of comic genius from the magazine\u2019s legendary Shouts and Murmurs page.\n\nThe New Yorker has set a standard in literary journalism for generations, and The New Yorker Radio Hour gives it a voice on public radio for the first time.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/9a96007e3fd1468573a640ca4301437b.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "0fd1be5c-9e07-4d7c-ba3c-7b108cf48ce5",
+            "name": "The Pulse",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "210f8cb2-1aa5-4f51-be53-841b667f49a1",
+            "name": "The Splendid Table",
+            "description": "",
+            "longDescription": "The Splendid Table has been celebrating the intersection of food and life for more than two decades. A culinary, culture and lifestyle program, it has hosted our nation\u0027s conversations about cooking, sustainability and food culture and has introduced us to generations of food dignitaries.\n\nRecently, Francis Lam was named host of the show. A regular contributor and frequent guest host on The Splendid Table since 2010, Lam is the former Eat columnist for The New York Times Magazine and is Editor-at-Large at Clarkson Potter, a division within Penguin Random House that is a leader in cookbook publishing. In his tenure at Clarkson Potter, he has been the editor behind some of the most creative and best-selling cookbooks and has worked with acclaimed authors, some of the country\u0027s hottest restaurateurs and chefs, as well as celebrities Chrissy Teigen and Questlove. For two seasons, Lam was a regular judge on Bravo\u0027s hit show, Top Chef Masters, a spinoff of Top Chef, where world-renowned chefs competed against each other in weekly challenges.\n\nThe show has been listed on numerous \u0022best of\u0022 podcast lists including a recent nod by the Huffington Post\u0027s Food Editor as the top food podcast...",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/c1f72b2068d545ef5c24dd7367dc49bb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "019c6d40-b695-7f08-a093-5ee195662fa6",
+            "name": "Theater of War: ICE in Our Schools",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "4b9b1a33-6ce7-4602-8e4f-d14b4f33a358",
+            "name": "This American Live",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "b604081d-5220-4092-9fec-20c90981652b",
+            "name": "Throughline",
+            "description": "",
+            "longDescription": "",
+            "images": [
+                {
+                    "url": "",
+                    "type": "largesquareimage",
+                    "width": 1280,
+                    "height": 1280
+                },
+                {
+                    "url": "",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                },
+                {
+                    "url": "",
+                    "type": "largerectangleimage",
+                    "width": 1280,
+                    "height": 800
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "b00b3fdd-1521-4dc5-a9b0-c70babc723fb",
+            "name": "Wait Wait... Don\u0027t Tell Me!",
+            "description": "",
+            "longDescription": "For a wacky and whip-smart approach to the week\u0027s news and newsmakers, listen no further than Wait Wait...Don\u0027t Tell Me!, the oddly informative news quiz from NPR. During each fast-paced, irreverent show, host Peter Sagal, along with judge and scorekeeper Bill Kurtis, leads callers, panelists, and guests through the week\u0027s events; identifying impersonations, sniffing out fake news items, and deciphering limericks. Listeners vie for a chance to win the most coveted prize in radio: a Wait Wait personality will record their voicemail greeting.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/b02ba07ea64b42be1c7b69665d2d70b0.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "a247770a-afbd-4d8f-88df-7a5594f93177",
+            "name": "Weekend Edition Saturday",
+            "description": "",
+            "longDescription": "NPR\u0027s two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/658ac7f45bfda071fd7b440d20816bdb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        },
+        {
+            "id": "0762826a-5320-4e2d-94f3-b37de4acbd7f",
+            "name": "Weekend Edition Sunday",
+            "description": "",
+            "longDescription": "NPR\u0027s two-hour weekend morning newsmagazine covering hard news, a wide variety of newsmakers, and cultural stories with care, accuracy, and a wink of humor.",
+            "images": [
+                {
+                    "url": "https://s3.us-east-1.amazonaws.com/webstream-assets-prod/01997cde6d76710ea058f2e53ceb3c49/658ac7f45bfda071fd7b440d20816bdb.jpg",
+                    "type": "imagepath",
+                    "width": 600,
+                    "height": 600
+                }
+            ],
+            "presenterIds": []
+        }
+    ],
+    "presenters": []
 }


### PR DESCRIPTION
This adds `longDescription` values to the BL and AOI shows in the WNYC schedule data, for use in review environments. 