### PR TITLE
WNYC-703 Fix images in preview

### DIFF
--- a/components/VImage.vue
+++ b/components/VImage.vue
@@ -179,6 +179,7 @@ const dynamicComponent = computed(() => {
       position: absolute;
       top: 0;
       left: 0;
+      height: 5px;
       opacity: 0;
       pointer-events: none;
     }


### PR DESCRIPTION
HTML based image lazy-loading (`loading="lazy"`) uses the image's position to detect when it should be loaded but the way the image was being hidden for the loading spinner made unloaded images not detected as loadable/visible in some circumstances and browsers, causing them to never load.

In this case images weren't loading when previewed in an iframe or in Safari.

Not sure of the specifics of the algorithm but manually setting a bit of height on the images in CSS allows them images to be measured by the browser's internal lazy loading algorithm and loaded when 'visible'.