### PR TITLE
Adding Abrev package to fix a dep issue

### DIFF
--- a/ios/App/Gemfile
+++ b/ios/App/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem 'cocoapods', '>= 1.16.0'
 gem 'fastlane'
+gem 'abbrev'
 
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/ios/App/Gemfile.lock
+++ b/ios/App/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     activesupport (7.2.3)
       base64
       benchmark (>= 0.3)
@@ -301,6 +302,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  abbrev
   cocoapods (>= 1.16.0)
   fastlane
 


### PR DESCRIPTION
Adding Abrev package to fix a dep issue in fastlane which was causing ios builds to fail.