### PR TITLE
Switch events list BFF to CMS /api/v2/events endpoint

### DIFF
--- a/server/api/events/list.ts
+++ b/server/api/events/list.ts
@@ -14,9 +14,8 @@ const getWagtailEvents = async (query: Record<string, any>) => {
     try {
         const options = {
             method: 'GET',
-            url: `${config.public.AVIARY_BASE_API}pages/`,
+            url: `${config.public.AVIARY_BASE_API}events/`,
             params: {
-                type: 'events.EventPage',
                 fields: 'id,title,start_datetime,end_datetime,duration,event_image,description,ticket_url,price,event_location,venue_name,event_url,body,tags,listing_title,listing_summary',
                 limit: query.limit || queryLimit,
                 offset: query.offset || 0,
@@ -26,13 +25,11 @@ const getWagtailEvents = async (query: Record<string, any>) => {
             }
         }
 
-        // Add date filtering if requested
+        // Pass explicit event mode params through to CMS endpoint
         if (query.upcoming === 'true') {
-            const now = new Date().toISOString().split('T')[0]; // Get date part only
-            (options.params as any).event_date__gte = now
+            (options.params as any).upcoming = true
         } else if (query.past === 'true') {
-            const now = new Date().toISOString().split('T')[0]; // Get date part only
-            (options.params as any).event_date__lt = now
+            (options.params as any).past = true
         }
 
         // Add venue filter if provided

--- a/tests/server/events.list.api.spec.ts
+++ b/tests/server/events.list.api.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const axiosMock = vi.fn()
+vi.mock('axios', () => ({ default: axiosMock }))
+
+vi.mock('~/server/utils/events', () => ({
+  normalizeWagtailEvent: (item: any) => item,
+}))
+
+let currentQuery: Record<string, any> = {}
+
+vi.mock('#imports', () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  useRuntimeConfig: () => ({
+    cmsSite: 'demo.wnyc.org:443',
+    public: { AVIARY_BASE_API: 'https://example.test/api/v2/' },
+  }),
+  getQuery: () => currentQuery,
+}))
+
+// @ts-expect-error test-only global
+globalThis.defineEventHandler = (handler: unknown) => handler
+// @ts-expect-error test-only global
+globalThis.useRuntimeConfig = () => ({
+  cmsSite: 'demo.wnyc.org:443',
+  public: { AVIARY_BASE_API: 'https://example.test/api/v2/' },
+})
+// @ts-expect-error test-only global
+globalThis.getQuery = () => currentQuery
+
+describe('server/api/events/list uses CMS events endpoint', () => {
+  beforeEach(() => {
+    currentQuery = {}
+    axiosMock.mockReset()
+    axiosMock.mockResolvedValue({
+      data: {
+        items: [{ id: 1, title: 'Example Event' }],
+        meta: { total_count: 1 },
+      },
+    })
+  })
+
+  it('calls /events/ without legacy date filters by default', async () => {
+    const handler = (await import('../../server/api/events/list')).default
+    const event: any = { node: { res: { setHeader: vi.fn() } } }
+
+    const result = await handler(event)
+    const call = axiosMock.mock.calls[0][0]
+
+    expect(call.url).toBe('https://example.test/api/v2/events/')
+    expect(call.params.type).toBeUndefined()
+    expect(call.params.event_date__gte).toBeUndefined()
+    expect(call.params.event_date__lt).toBeUndefined()
+    expect(result.meta.totalCount).toBe(1)
+  })
+
+  it('forwards upcoming/past flags to CMS endpoint', async () => {
+    const handler = (await import('../../server/api/events/list')).default
+    const event: any = { node: { res: { setHeader: vi.fn() } } }
+
+    currentQuery = { upcoming: 'true' }
+    await handler(event)
+    let call = axiosMock.mock.calls[0][0]
+    expect(call.params.upcoming).toBe(true)
+    expect(call.params.past).toBeUndefined()
+
+    currentQuery = { past: 'true' }
+    await handler(event)
+    call = axiosMock.mock.calls[1][0]
+    expect(call.params.past).toBe(true)
+    expect(call.params.upcoming).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- update `server/api/events/list.ts` to call `/api/v2/events/` instead of `/api/v2/pages/`
- remove legacy date-only `event_date__gte` / `event_date__lt` filters from the BFF
- pass through `upcoming` / `past` params to CMS endpoint
- add server API tests verifying endpoint path and query forwarding

## Testing
- `npm run test -- --run tests/server/events.list.api.spec.ts`
