### PR TITLE
Remove blank placeholder templates

### DIFF
--- a/pages/100.vue
+++ b/pages/100.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>100 Years</h1>
-  </section>
-</template>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>About</h1>
-  </section>
-</template>

--- a/pages/careers.vue
+++ b/pages/careers.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Careers</h1>
-  </section>
-</template>

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Community</h1>
-  </section>
-</template>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Contact</h1>
-  </section>
-</template>

--- a/pages/corrections.vue
+++ b/pages/corrections.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Corrections</h1>
-  </section>
-</template>

--- a/pages/diversity-dei-overview.vue
+++ b/pages/diversity-dei-overview.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Diversity DEI Overview</h1>
-  </section>
-</template>

--- a/pages/donate.vue
+++ b/pages/donate.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Donate</h1>
-  </section>
-</template>

--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="privacy-page">
-    <h1>Newsletter</h1>
-  </section>
-</template>

--- a/pages/press.vue
+++ b/pages/press.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="privacy-page">
-    <h1>Press</h1>
-  </section>
-</template>

--- a/pages/support.vue
+++ b/pages/support.vue
@@ -1,5 +1,0 @@
-<template>
-  <section class="py-6">
-    <h1>Support</h1>
-  </section>
-</template>


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/WNYC-756
These blank pages are blocking information pages from being created at the same URL and also if we leave them in they'll probably start showing up in Google searches or something.

We should replace them with regular information pages with real information if possible.