### PR TITLE
remove "the" from slug normalization to match legacy format

### DIFF
--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -105,6 +105,7 @@ const normalizeSchedule = (scheduleData: any): any[] => {
                 .replace(/\s+/g, '-')      // Replace spaces with hyphens
                 .replace(/-+/g, '-')       // Replace multiple hyphens with single
                 .replace(/^-|-$/g, '')     // Remove leading/trailing hyphens
+                .replace(/\bthe-\b/g, '')   // Remove "the" to match legacy slug format
             parentUrl = `https://www.wnyc.org${mediaTypeRoutes.show}${slug}`
         }
 


### PR DESCRIPTION
Filtering out the from the generated slug in the rapid schedule url.