### PR TITLE
Bono/wnyc 816 shareUrl addition

### DIFF
--- a/composables/data/articlePages.ts
+++ b/composables/data/articlePages.ts
@@ -192,9 +192,9 @@ export function normalizePerson (person: Record<string, any>): Person {
 
 // Wagtail: Transform page data from the API into a simpler and typed format
 export async function normalizeWagtailPage (article: Record<string, any | undefined>): ArticlePage {
-  const config = useRuntimeConfig()
   if (typeof article === 'undefined')
     return null
+  const config = useRuntimeConfig()
   return Object.assign({}, await normalizePage(article), {
     description: article.description,
     image: article.leadAsset?.[0]?.value?.image ?? article.leadAsset?.[0]?.value?.defaultImage ?? article.showArt,

--- a/composables/data/articlePages.ts
+++ b/composables/data/articlePages.ts
@@ -321,7 +321,7 @@ export async function normalizeSimplecastListItem (article: Record<string, any |
   if (typeof article === 'undefined')
     return null
   //console.log("normalizeSimplecastListItem", article)
-
+  const config = useRuntimeConfig()
   // Simplecast uses UUIDs as episode IDs - preserve the original UUID for API calls
   const simplecastId = article.id || article.episodeId || article.uuid
 
@@ -352,7 +352,7 @@ export async function normalizeSimplecastListItem (article: Record<string, any |
     sponsoredContent: undefined,
     relatedLinks: undefined,
     url: article.url,
-    shareUrl: article.url,
+    shareUrl: `${config.public.BFF_URL}${mediaTypeRoutes.simplecast}${simplecastId}`,
     link: `${mediaTypeRoutes.simplecast}${simplecastId}`,
     section: undefined,
     //rawBody: getWagtailRawBody(article.body),

--- a/composables/data/articlePages.ts
+++ b/composables/data/articlePages.ts
@@ -949,6 +949,7 @@ const extractImageDimensions = (image?: string): { w: number; h: number } => {
 
 // Normalize an article page object from NPR into a generic ArticlePage object.
 export async function normalizeNprPage (article: NprArticle, componentType = "default", showSlug?: string): Promise<ArticlePage> {
+  const config = useRuntimeConfig()
   const id = article.id
   const firstImageHref = article.images?.[0]?.href
   const rawImageId = firstImageHref?.substring(firstImageHref.lastIndexOf("/") + 1)
@@ -1019,6 +1020,7 @@ export async function normalizeNprPage (article: NprArticle, componentType = "de
     body: textBody,
     rawBody: textBody,
     link: article.webPages?.[0]?.href ?? '/',
+    url: `${config.public.BFF_URL}${mediaTypeRoutes[mediaTypes.NPR_ARTICLE]}${article.id}`,
     authors,
   })
 }

--- a/composables/data/articlePages.ts
+++ b/composables/data/articlePages.ts
@@ -104,6 +104,7 @@ function getArticleLink (articleData): string {
 
 // Transform author data from the API into a simpler and typed format
 export function normalizeAuthor (author: Record<string, any>): Author {
+  const config = useRuntimeConfig()
   return {
     id: author.id,
     firstName: author.firstName,
@@ -118,6 +119,7 @@ export function normalizeAuthor (author: Record<string, any>): Author {
     email: author.email,
     slug: author.slug,
     url: author.slug && `/staff/${author.slug}`,
+    shareUrl: `${config.public.BFF_URL}${mediaTypeRoutes[mediaTypes.STAFF]}${author.slug}`,
     socialMediaProfile: author.socialMediaProfile,
   }
 }
@@ -168,6 +170,7 @@ function normalizePersonSocial (social: Record<string, any>): ISocial {
 
 // Transform person data from the API into a simpler and typed format
 export function normalizePerson (person: Record<string, any>): Person {
+  const config = useRuntimeConfig()
   const pa = person.attributes
   return {
     id: person.id,
@@ -180,6 +183,7 @@ export function normalizePerson (person: Record<string, any>): Person {
     email: pa.email,
     slug: pa.slug,
     url: `/people/${pa.slug}`,
+    shareUrl: `${config.public.BFF_URL}${mediaTypeRoutes[mediaTypes.PEOPLE]}${pa.slug}`,
     socialMediaProfile: pa.social.length > 0 ? pa.social.map(normalizePersonSocial) : null, // Fix: Wrap the normalizePersonSocial result in an array
     shows: pa.shows,
   }
@@ -188,6 +192,7 @@ export function normalizePerson (person: Record<string, any>): Person {
 
 // Wagtail: Transform page data from the API into a simpler and typed format
 export async function normalizeWagtailPage (article: Record<string, any | undefined>): ArticlePage {
+  const config = useRuntimeConfig()
   if (typeof article === 'undefined')
     return null
   return Object.assign({}, await normalizePage(article), {
@@ -217,6 +222,7 @@ export async function normalizeWagtailPage (article: Record<string, any | undefi
     tags: article.tags,
     //url: article.url,
     url: null,
+    shareUrl: `${config.public.BFF_URL}${getWagtailArticleLink(article)}`,
     section: { name: article.ancestry?.[0].title, slug: article.ancestry?.[0].slug },
     body: article.body,
     rawBody: getWagtailRawBody(article.body),
@@ -278,6 +284,7 @@ export async function normalizeWagtailListItem (article: Record<string, any | un
     sponsoredContent: article.sponsoredContent,
     relatedLinks: article.relatedLinks,
     url: article.url,
+    shareUrl: article.url,
     section: { name: article.ancestry?.[0].title, slug: article.ancestry?.[0].slug },
     rawBody: getWagtailRawBody(article.body),
     audio: article.audio,
@@ -345,6 +352,7 @@ export async function normalizeSimplecastListItem (article: Record<string, any |
     sponsoredContent: undefined,
     relatedLinks: undefined,
     url: article.url,
+    shareUrl: article.url,
     link: `${mediaTypeRoutes.simplecast}${simplecastId}`,
     section: undefined,
     //rawBody: getWagtailRawBody(article.body),
@@ -434,7 +442,7 @@ async function getSimplecastDuration (article: SimplecastArticle): Promise<numbe
 export async function normalizeSimplecastPage (article: SimplecastArticle): Promise<ArticlePage> {
   if (typeof article === 'undefined')
     return null
-
+  const config = useRuntimeConfig()
   const duration = await getSimplecastDuration(article)
   const simplecastId = article.id
   const { showId, showTitle, showImageUrl } = getSimplecastShowInfo(article)
@@ -481,6 +489,7 @@ export async function normalizeSimplecastPage (article: SimplecastArticle): Prom
     tags: getSimplecastTags(article),
     //url: article.episodeUrl,
     url: null,
+    shareUrl: `${config.public.BFF_URL}${mediaTypeRoutes.simplecast}${simplecastId}`,
     section: undefined,
     body: bodyText,
     rawBody: bodyText,
@@ -527,6 +536,7 @@ export async function normalizePublisherPage (article: Record<string, any | unde
     })
   }
   const authors = article.attributes.appearances?.authors.map(normalizeAuthor)
+  const config = useRuntimeConfig()
   // Remove publisher author fields because we don't haven't built out the author pages for publisher
   authors.forEach((author) => {
     delete author.slug
@@ -568,6 +578,7 @@ export async function normalizePublisherPage (article: Record<string, any | unde
     tags: article.attributes?.tags, // This may need tweaking
     //url: article.attributes.url,
     url: null,
+    shareUrl: `${config.public.BFF_URL}${getPublisherArticleLink(article)}`,
     section: undefined, //Does this exist in publisher?
     body: article.attributes.body,
     rawBody: article.attributes.body,
@@ -629,6 +640,7 @@ export async function normalizePublisherListItem (article: Record<string, any | 
     contributingOrganizations: article.attributes?.producingOrganizations,
     publicationDate: article.attributes.publishAt && new Date(article.attributes.publishAt),
     url: article.attributes.url,
+    shareUrl: article.attributes.url,
     rawBody: null,
     body: article.attributes.body,
     audio: article.attributes.audio,
@@ -1020,7 +1032,7 @@ export async function normalizeNprPage (article: NprArticle, componentType = "de
     body: textBody,
     rawBody: textBody,
     link: article.webPages?.[0]?.href ?? '/',
-    url: `${config.public.BFF_URL}${mediaTypeRoutes[mediaTypes.NPR_ARTICLE]}${article.id}`,
+    shareUrl: `${config.public.BFF_URL}${mediaTypeRoutes[mediaTypes.NPR_ARTICLE]}${article.id}`,
     authors,
   })
 }
@@ -1177,6 +1189,7 @@ export function normalizeSearchResults (results: Record<string, any | undefined>
     relatedLinks: result.relatedLinks,
     tags: result.tags,
     url: result.url,
+    shareUrl: result.url,
     uuid: result.uuid,
     section: getSectionInfo(result),
     body: result.body,

--- a/composables/globals.ts
+++ b/composables/globals.ts
@@ -60,9 +60,13 @@ export const mediaTypes = {
     NPR_EPISODE: 'npr_episode',
     NPR_ARTICLE: 'npr_article',
     CARD: 'card',
+    STAFF: 'staff',
+    PEOPLE: 'people',
 }
 
 export const mediaTypeRoutes = {
+    [mediaTypes.STAFF]: '/staff/',
+    [mediaTypes.PEOPLE]: '/people/',
     [mediaTypes.LIVE]: '/live/',
     [mediaTypes.SHOW]: '/browse/shows/',
     [mediaTypes.EPISODE]: '/browse/shows/episode/',

--- a/composables/types/Author.ts
+++ b/composables/types/Author.ts
@@ -21,4 +21,5 @@ export default interface Author {
   website?: string
   email?: string
   slug?: string
+  shareUrl?: string
 }

--- a/composables/types/Page.ts
+++ b/composables/types/Page.ts
@@ -107,6 +107,7 @@ export interface ArticlePage extends Page {
   relatedLinks?: NavigationLink[]
   tags?: Tag[]
   url?: string
+  shareUrl?: string
   uuid: string
   section?: Tag
   body?: StreamfieldBlock[] | string

--- a/composables/types/Person.ts
+++ b/composables/types/Person.ts
@@ -7,6 +7,7 @@ interface IShow {
 export default interface Person {
   id?: number
   url?: string
+  shareUrl?: string
   name?: string
   socialMediaProfile?: ISocial[]
   photoID?: any

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -233,7 +233,7 @@ export default defineNuxtConfig({
       FB_APP_ID_IOS: process.env.FB_APP_ID_IOS,
       FB_APP_ID_ANDROID: process.env.FB_APP_ID_ANDROID,
       ONESIGNAL_APP_ID: process.env.ONESIGNAL_APP_ID,
-      BFF_URL: process.env.BFF_URL ?? "https://demo.native-app.wnyc.org",
+      BFF_URL: process.env.BFF_URL ?? "https://demo.wnyc.org",
       GTM_ID: process.env.GTM_ID ?? "GTM-TKFJ684",
       environment: process.env.environment ?? "prod",
       supabaseUrl: process.env.SUPABASE_URL,

--- a/tests/server/pages.api.spec.ts
+++ b/tests/server/pages.api.spec.ts
@@ -44,6 +44,9 @@ globalThis.__testRuntimeConfig = {
   },
 }
 
+// @ts-expect-error - mock useRuntimeConfig for test environment
+globalThis.useRuntimeConfig = () => globalThis.__testRuntimeConfig
+
 describe('server/api/pages [wagtail] passes through body.curated_list', () => {
   beforeEach(() => {
     axiosMock.mockClear()

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -465,7 +465,7 @@ export const shareAPI = async (
   const shareData = {
     title: stripHtmlTags(content.socialTitle || content.title),
     text: stripHtmlTags(content.rawBody || content.description || content.title),
-    url: content.url || content.titleLink,
+    url: content.shareUrl || content.url || content.titleLink,
   }
 
   trackClickEvent("Click Tracking - Share", componentOfOrigin, shareData.title)

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -461,6 +461,7 @@ export const shareAPI = async (
   content,
   componentOfOrigin = "Component of origin not specified"
 ) => {
+  console.log('content', content)
   const shareData = {
     title: stripHtmlTags(content.socialTitle || content.title),
     text: stripHtmlTags(content.rawBody || content.description || content.title),

--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -461,13 +461,11 @@ export const shareAPI = async (
   content,
   componentOfOrigin = "Component of origin not specified"
 ) => {
-  console.log('content', content)
   const shareData = {
     title: stripHtmlTags(content.socialTitle || content.title),
     text: stripHtmlTags(content.rawBody || content.description || content.title),
     url: content.shareUrl || content.url || content.titleLink,
   }
-
   trackClickEvent("Click Tracking - Share", componentOfOrigin, shareData.title)
   // Native Mobile Sharing
   if (Capacitor.isNativePlatform()) {


### PR DESCRIPTION
we used to use the url, but we stopped populating the url for when we save to Supabase, so I created a new shareUrl that I added to all the normalizers and updated the interfaces. 

And yes, I have a problem... but it was either do this while watching TV, or doom scroll.