### PR TITLE
WNYC-826-830

### DIFF
--- a/utilities/helpers.ts
+++ b/utilities/helpers.ts
@@ -78,9 +78,12 @@ export const slugify = (text) => {
 export const getRouteOrLink = (
   url: string,
   routingDomains: string[] = [
-    "www.wnyc.org",
+    "wnyc.org",
     "demo.wnyc.org",
+    "prod.wnyc.org",
+    "www.wnyc.org",
     "www.demo.wnyc.org",
+    "www.prod.wnyc.org",
   ]
 ) => {
   if (!url) return url


### PR DESCRIPTION
added prod domain to the getRouteOrLink helper function.

This function detects if the incoming url has these domains... if so, it's a route, and returns the path ony, otherwise, it returns the entire url