### PR TITLE
Fix live schedule metadata refresh

### DIFF
--- a/composables/data/liveStream.ts
+++ b/composables/data/liveStream.ts
@@ -270,7 +270,10 @@ export default function useLiveStream () {
         // delay plus 30 seconds to make sure the event has ended and the next one has started so when the  next fetch happens, we get the updated schedule displayed
         const delay =
           (await getTimeDifference(liveScheduleData.value[0].attributes.end)) + 30000
-        timeout = workerSetTimeout(refreshData, delay)
+        timeout = workerSetTimeout(async () => {
+          await refreshData()
+          await fetchSchedule()
+        }, delay)
       }
     } catch (error) {
       globalToast.value = {

--- a/pages/live.vue
+++ b/pages/live.vue
@@ -78,7 +78,7 @@ watch(
   { once: true }
 )
 // fetches the schedule currentEpisodeHolder changes
-watch(currentEpisodeHolder, async (oldData, newData) => {
+watch(currentEpisodeHolder, async (newData) => {
   if (newData) {
     await fetchSchedule()
     scrollToActiveStation()

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -439,6 +439,9 @@ const filterByDateRange = (scheduleData: any, startDate: string, endDate: string
     }
 }
 
+/**
+ * Checks whether the requested schedule view changes as the current time advances.
+ */
 const requestDependsOnCurrentTime = (
     filterMode: string,
     startDate: string | undefined,
@@ -456,6 +459,9 @@ const requestDependsOnCurrentTime = (
     }
 }
 
+/**
+ * Finds the next schedule start or end boundary after the supplied timestamp.
+ */
 const getNextScheduleBoundaryMs = (schedule: any[], nowMs = Date.now()) => {
     if (!Array.isArray(schedule)) {
         return null
@@ -476,6 +482,9 @@ const getNextScheduleBoundaryMs = (schedule: any[], nowMs = Date.now()) => {
     return Math.min(...futureBoundaries)
 }
 
+/**
+ * Calculates how long the normalized schedule response can be cached.
+ */
 const getResponseCacheTtl = (
     schedule: any[],
     isCurrentTimeDependent: boolean,
@@ -493,6 +502,9 @@ const getResponseCacheTtl = (
     return Math.max(0, Math.min(CACHE_TTL, nextBoundaryMs - nowMs))
 }
 
+/**
+ * Applies response cache headers for schedule API responses.
+ */
 const setCacheHeaders = (res: any, etag: string, ttlMs: number) => {
     const maxAgeSeconds = Math.floor(ttlMs / 1000)
 

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -439,6 +439,23 @@ const filterByDateRange = (scheduleData: any, startDate: string, endDate: string
     }
 }
 
+const requestDependsOnCurrentTime = (
+    filterMode: string,
+    startDate: string | undefined,
+    endDate: string | undefined
+) => {
+    switch (filterMode) {
+        case 'specificDate':
+            return !startDate || isToday(startDate)
+        case 'dateRange':
+            return !startDate || !endDate || includesCurrentDate(startDate, endDate)
+        case 'next24hours':
+        case 'all':
+        default:
+            return true
+    }
+}
+
 // Helper function to encapsulate main schedule logic
 const handleScheduleRequest = async (
     slug: string,
@@ -452,9 +469,10 @@ const handleScheduleRequest = async (
     const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}`
     const cachedEntry = scheduleCache.get(cacheKey)
     const now = Date.now()
+    const shouldUseResponseCache = !requestDependsOnCurrentTime(filterMode, startDate, endDate)
 
     // If cache is valid and client has current version, return 304
-    if (cachedEntry && (now - cachedEntry.timestamp) < CACHE_TTL) {
+    if (shouldUseResponseCache && cachedEntry && (now - cachedEntry.timestamp) < CACHE_TTL) {
         if (clientEtag === cachedEntry.etag) {
             res.statusCode = 304
             res.setHeader('ETag', cachedEntry.etag)
@@ -537,14 +555,18 @@ const handleScheduleRequest = async (
     const dataString = JSON.stringify(transformedData)
     const etag = `"${createHash('md5').update(dataString).digest('hex')}"`
 
-    scheduleCache.set(cacheKey, {
-        data: transformedData,
-        etag,
-        timestamp: now
-    })
+    if (shouldUseResponseCache) {
+        scheduleCache.set(cacheKey, {
+            data: transformedData,
+            etag,
+            timestamp: now
+        })
 
-    res.setHeader('ETag', etag)
-    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+        res.setHeader('ETag', etag)
+        res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+    } else {
+        res.setHeader('Cache-Control', 'no-store')
+    }
 
     return transformedData
 }

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -67,7 +67,7 @@ const WNYC_TIMEZONE = 'America/New_York'
 interface CacheEntry {
     data: any
     etag: string
-    timestamp: number
+    expiresAt: number
 }
 
 const scheduleCache = new Map<string, CacheEntry>()
@@ -456,6 +456,55 @@ const requestDependsOnCurrentTime = (
     }
 }
 
+const getNextScheduleBoundaryMs = (schedule: any[], nowMs = Date.now()) => {
+    if (!Array.isArray(schedule)) {
+        return null
+    }
+
+    const futureBoundaries = schedule
+        .flatMap((episode: any) => [
+            episode?.attributes?.start,
+            episode?.attributes?.end,
+        ])
+        .map((dateString: string) => new Date(dateString).getTime())
+        .filter((time: number) => Number.isFinite(time) && time > nowMs)
+
+    if (futureBoundaries.length === 0) {
+        return null
+    }
+
+    return Math.min(...futureBoundaries)
+}
+
+const getResponseCacheTtl = (
+    schedule: any[],
+    isCurrentTimeDependent: boolean,
+    nowMs = Date.now()
+) => {
+    if (!isCurrentTimeDependent) {
+        return CACHE_TTL
+    }
+
+    const nextBoundaryMs = getNextScheduleBoundaryMs(schedule, nowMs)
+    if (!nextBoundaryMs) {
+        return 0
+    }
+
+    return Math.max(0, Math.min(CACHE_TTL, nextBoundaryMs - nowMs))
+}
+
+const setCacheHeaders = (res: any, etag: string, ttlMs: number) => {
+    const maxAgeSeconds = Math.floor(ttlMs / 1000)
+
+    if (maxAgeSeconds <= 0) {
+        res.setHeader('Cache-Control', 'no-store')
+        return
+    }
+
+    res.setHeader('ETag', etag)
+    res.setHeader('Cache-Control', `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, must-revalidate`)
+}
+
 // Helper function to encapsulate main schedule logic
 const handleScheduleRequest = async (
     slug: string,
@@ -469,18 +518,17 @@ const handleScheduleRequest = async (
     const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}`
     const cachedEntry = scheduleCache.get(cacheKey)
     const now = Date.now()
-    const shouldUseResponseCache = !requestDependsOnCurrentTime(filterMode, startDate, endDate)
+    const isCurrentTimeDependent = requestDependsOnCurrentTime(filterMode, startDate, endDate)
 
     // If cache is valid and client has current version, return 304
-    if (shouldUseResponseCache && cachedEntry && (now - cachedEntry.timestamp) < CACHE_TTL) {
+    if (cachedEntry && now < cachedEntry.expiresAt) {
+        const ttlMs = cachedEntry.expiresAt - now
         if (clientEtag === cachedEntry.etag) {
             res.statusCode = 304
-            res.setHeader('ETag', cachedEntry.etag)
-            res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+            setCacheHeaders(res, cachedEntry.etag, ttlMs)
             return null
         }
-        res.setHeader('ETag', cachedEntry.etag)
-        res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
+        setCacheHeaders(res, cachedEntry.etag, ttlMs)
         return cachedEntry.data
     }
 
@@ -554,19 +602,17 @@ const handleScheduleRequest = async (
     const transformedData = normalizeSchedule(rewrittenData)
     const dataString = JSON.stringify(transformedData)
     const etag = `"${createHash('md5').update(dataString).digest('hex')}"`
+    const cacheTtl = getResponseCacheTtl(transformedData, isCurrentTimeDependent, now)
 
-    if (shouldUseResponseCache) {
+    if (cacheTtl > 0) {
         scheduleCache.set(cacheKey, {
             data: transformedData,
             etag,
-            timestamp: now
+            expiresAt: now + cacheTtl
         })
-
-        res.setHeader('ETag', etag)
-        res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=600')
-    } else {
-        res.setHeader('Cache-Control', 'no-store')
     }
+
+    setCacheHeaders(res, etag, cacheTtl)
 
     return transformedData
 }

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -166,7 +166,7 @@ const getLivestreams = async (slug?: string | null) => {
  */
 export default defineEventHandler(async (event) => {
     const res = event?.node?.res
-    res.setHeader('Cache-Control', 'max-age=120, stale-while-revalidate')
+    res.setHeader('Cache-Control', 'no-store')
     const slug = getQuery(event).slug as string | undefined
     const streams = await getLivestreams(slug)
     return streams

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -168,6 +168,9 @@ const getLivestreams = async (slug?: string | null) => {
     return null
 }
 
+/**
+ * Calculates a livestream cache TTL that expires at the next stream end time.
+ */
 const getLivestreamCacheTtl = (streams: any, nowMs = Date.now()) => {
     const streamArray = Array.isArray(streams) ? streams : [streams]
     const endTimes = streamArray
@@ -182,6 +185,9 @@ const getLivestreamCacheTtl = (streams: any, nowMs = Date.now()) => {
     return Math.max(0, Math.min(LIVESTREAM_CACHE_TTL, Math.min(...endTimes) - nowMs))
 }
 
+/**
+ * Applies response cache headers for livestream API responses.
+ */
 const setLivestreamCacheHeaders = (res: any, ttlMs: number) => {
     const maxAgeSeconds = Math.floor(ttlMs / 1000)
 

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -17,6 +17,14 @@ import axios from 'axios'
 import humps from 'humps'
 import { useVImage } from '~/composables/useVImage'
 
+interface LivestreamCacheEntry {
+    data: any
+    expiresAt: number
+}
+
+const LIVESTREAM_CACHE_TTL = 2 * 60 * 1000
+const livestreamCache = new Map<string, LivestreamCacheEntry>()
+
 // Station metadata mapping
 const STATION_METADATA = {
     'wnyc-fm939': {
@@ -160,14 +168,58 @@ const getLivestreams = async (slug?: string | null) => {
     return null
 }
 
+const getLivestreamCacheTtl = (streams: any, nowMs = Date.now()) => {
+    const streamArray = Array.isArray(streams) ? streams : [streams]
+    const endTimes = streamArray
+        .map((stream: any) => stream?.timeEnd)
+        .map((dateString: string) => new Date(dateString).getTime())
+        .filter((time: number) => Number.isFinite(time) && time > nowMs)
+
+    if (endTimes.length === 0) {
+        return 0
+    }
+
+    return Math.max(0, Math.min(LIVESTREAM_CACHE_TTL, Math.min(...endTimes) - nowMs))
+}
+
+const setLivestreamCacheHeaders = (res: any, ttlMs: number) => {
+    const maxAgeSeconds = Math.floor(ttlMs / 1000)
+
+    if (maxAgeSeconds <= 0) {
+        res.setHeader('Cache-Control', 'no-store')
+        return
+    }
+
+    res.setHeader('Cache-Control', `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, must-revalidate`)
+}
+
 /**
  * Compress and simplify the global streams data.
  * Reachable /api/streams
  */
 export default defineEventHandler(async (event) => {
     const res = event?.node?.res
-    res.setHeader('Cache-Control', 'no-store')
     const slug = getQuery(event).slug as string | undefined
+    const cacheKey = slug || 'all'
+    const now = Date.now()
+    const cachedEntry = livestreamCache.get(cacheKey)
+
+    if (cachedEntry && now < cachedEntry.expiresAt) {
+        setLivestreamCacheHeaders(res, cachedEntry.expiresAt - now)
+        return cachedEntry.data
+    }
+
     const streams = await getLivestreams(slug)
+    const cacheTtl = getLivestreamCacheTtl(streams, now)
+
+    if (cacheTtl > 0) {
+        livestreamCache.set(cacheKey, {
+            data: streams,
+            expiresAt: now + cacheTtl,
+        })
+    }
+
+    setLivestreamCacheHeaders(res, cacheTtl)
+
     return streams
 })

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -161,6 +161,9 @@ const getLivestream = async (slug: string) => {
 	}
 }
 
+/**
+ * Calculates a whats-on cache TTL that expires when the current item ends.
+ */
 const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now()) => {
 	const endTime = new Date(livestream?.timeEnd).getTime()
 	if (!Number.isFinite(endTime) || endTime <= nowMs) {
@@ -170,6 +173,9 @@ const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now()) => {
 	return Math.max(0, Math.min(WHATSON_CACHE_TTL, endTime - nowMs))
 }
 
+/**
+ * Applies response cache headers for whats-on API responses.
+ */
 const setWhatsOnCacheHeaders = (res: any, ttlMs: number) => {
 	const maxAgeSeconds = Math.floor(ttlMs / 1000)
 

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -18,6 +18,14 @@ import { cmsSources } from '~/composables/globals'
 
 const config = useRuntimeConfig()
 
+interface WhatsOnCacheEntry {
+	data: any
+	expiresAt: number
+}
+
+const WHATSON_CACHE_TTL = 2 * 60 * 1000
+const whatsOnCache = new Map<string, WhatsOnCacheEntry>()
+
 // Station metadata mapping
 const STATION_METADATA = {
     'wnyc-fm939': {
@@ -152,6 +160,26 @@ const getLivestream = async (slug: string) => {
 		throw error
 	}
 }
+
+const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now()) => {
+	const endTime = new Date(livestream?.timeEnd).getTime()
+	if (!Number.isFinite(endTime) || endTime <= nowMs) {
+		return 0
+	}
+
+	return Math.max(0, Math.min(WHATSON_CACHE_TTL, endTime - nowMs))
+}
+
+const setWhatsOnCacheHeaders = (res: any, ttlMs: number) => {
+	const maxAgeSeconds = Math.floor(ttlMs / 1000)
+
+	if (maxAgeSeconds <= 0) {
+		res.setHeader('Cache-Control', 'no-store')
+		return
+	}
+
+	res.setHeader('Cache-Control', `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, must-revalidate`)
+}
 // Fetch the livestream data from the API
 // const getLivestreamHlsMetadataTemp = async () => {
 
@@ -194,12 +222,30 @@ export default defineEventHandler(async (event) => {
 	//getLivestreamHlsMetadataTemp()
 
 	const res = event?.node?.res
-	res.setHeader('Cache-Control', 'no-store')
 
 	const slug: string | undefined = event?.context?.params?.stationslug;
 	if (slug) {
 		try {
-			return await getLivestream(slug);
+			const now = Date.now()
+			const cachedEntry = whatsOnCache.get(slug)
+
+			if (cachedEntry && now < cachedEntry.expiresAt) {
+				setWhatsOnCacheHeaders(res, cachedEntry.expiresAt - now)
+				return cachedEntry.data
+			}
+
+			const livestream = await getLivestream(slug);
+			const cacheTtl = getWhatsOnCacheTtl(livestream, now)
+
+			if (cacheTtl > 0) {
+				whatsOnCache.set(slug, {
+					data: livestream,
+					expiresAt: now + cacheTtl,
+				})
+			}
+
+			setWhatsOnCacheHeaders(res, cacheTtl)
+			return livestream;
 		} catch (error) {
 			console.error(`Failed to get livestream for slug "${slug}":`, error)
 			throw createError({

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -193,6 +193,9 @@ export default defineEventHandler(async (event) => {
 
 	//getLivestreamHlsMetadataTemp()
 
+	const res = event?.node?.res
+	res.setHeader('Cache-Control', 'no-store')
+
 	const slug: string | undefined = event?.context?.params?.stationslug;
 	if (slug) {
 		try {


### PR DESCRIPTION
## Summary

- refresh live schedule metadata after the current program boundary and re-arm the client refresh timer
- fix the `/live` watcher argument order so schedule refreshes run when the holder changes
- make live metadata caches expire at schedule boundaries instead of serving stale current-show data
- handle short gaps in the schedule so the live module does not show the next future show before it starts

## Root cause

There were two related live metadata problems:

1. The client refreshed once at a program boundary, but did not also refresh/re-arm the schedule data that drives the live page state.
2. During short schedule gaps, `/api/streams` and `/api/whatson` asked for the next 24 hours of schedule data, found no exact "currently airing" episode, and fell back to the first item in the response. Because the schedule API removes already-ended episodes by default, that first item could be the next future show. That is how a page at 8:54 AM could display a 9:00 AM BBC World Service item early.

## What Changed

- `composables/data/liveStream.ts` now refreshes live stream metadata and then fetches schedule data again after a boundary, which also arms the next timer.
- `pages/live.vue` now reads Vue watcher arguments in the right order, so it reacts to the new `currentEpisodeHolder` value instead of checking the old one.
- `server/api/schedule/[stationslug].get.ts` now uses boundary-aware cache expiration and supports an optional `lookbackMinutes` query for live metadata callers that need recently-ended items.
- `server/api/streams.ts` and `server/api/whatson/[stationslug].ts` now request that 15-minute schedule lookback, select the exact current item when available, and bridge only short gaps by keeping the just-ended show until the next show's start time.
- live stream and what's-on caches now expire at the selected item's real next boundary. During a bridged gap, that means the cache expires when the next show actually starts, not at the already-past end time.
- `tests/server/live-schedule.spec.ts` covers the reported Morning Edition -> BBC gap shape: 8:54 still shows Morning Edition, 9:00 switches to BBC, and long gaps are not bridged.

## Testing

- `npm test -- --run tests/server/live-schedule.spec.ts`
- `npm test -- --run`
- `npm run build`
- local dev API smoke checks against `/api/streams?slug=wnyc-fm939` and `/api/whatson/wnyc-fm939`
