### PR TITLE
Handle short live schedule gaps

### DIFF
--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -20,6 +20,7 @@
  * - filterMode: 'next24hours' | 'specificDate' | 'dateRange' | 'all' (default: 'all')
  * - startDate: (optional) ISO date string for filtering (YYYY-MM-DD) - interpreted in America/New_York timezone (EST/EDT)
  * - endDate: (optional) ISO date string for filtering (YYYY-MM-DD) - interpreted in America/New_York timezone (EST/EDT), used with dateRange mode
+ * - lookbackMinutes: (optional) include recently-ended episodes for live metadata gap handling
  * 
  * Timezone Handling:
  * - All date parameters are interpreted in America/New_York timezone (EST/EDT)
@@ -72,6 +73,7 @@ interface CacheEntry {
 
 const scheduleCache = new Map<string, CacheEntry>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes in milliseconds
+const MAX_LOOKBACK_MINUTES = 60
 
 // Transform v2 data structure to match old schedule endpoint format
 const normalizeSchedule = (scheduleData: any): any[] => {
@@ -240,15 +242,20 @@ const getScheduleFromS3 = async (bucketName: string, key: string) => {
 }
 
 // Remove past episodes that have already aired
-const removePastEpisodes = (scheduleData: any) => {
+const getLookbackStart = (now: Date, lookbackMinutes: number) => (
+    new Date(now.getTime() - Math.max(0, lookbackMinutes) * 60 * 1000)
+)
+
+const removePastEpisodes = (scheduleData: any, lookbackMinutes = 0) => {
     if (!scheduleData.episodes || !Array.isArray(scheduleData.episodes)) {
         return scheduleData
     }
 
     const now = new Date()
+    const lookbackStart = getLookbackStart(now, lookbackMinutes)
     const filteredEpisodes = scheduleData.episodes.filter((episode: any) => {
         const endTime = new Date(episode.endTime)
-        return endTime > now
+        return endTime > lookbackStart
     })
 
     return {
@@ -274,19 +281,20 @@ const includesCurrentDate = (startDate: string, endDate: string): boolean => {
 }
 
 // Filter episodes for the next 24 hours
-const filterNext24Hours = (scheduleData: any) => {
+const filterNext24Hours = (scheduleData: any, lookbackMinutes = 0) => {
     if (!scheduleData.episodes || !Array.isArray(scheduleData.episodes)) {
         return scheduleData
     }
 
     const now = new Date()
+    const lookbackStart = getLookbackStart(now, lookbackMinutes)
     const next24Hours = new Date(now.getTime() + 24 * 60 * 60 * 1000)
 
     const filteredEpisodes = scheduleData.episodes.filter((episode: any) => {
         const startTime = new Date(episode.startTime)
         const endTime = new Date(episode.endTime)
         // Include episodes that start within the next 24 hours or are currently airing
-        return endTime > now && startTime < next24Hours
+        return endTime > lookbackStart && startTime < next24Hours
     })
 
     return {
@@ -517,17 +525,29 @@ const setCacheHeaders = (res: any, etag: string, ttlMs: number) => {
     res.setHeader('Cache-Control', `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, must-revalidate`)
 }
 
+const parseLookbackMinutes = (lookbackMinutes: unknown) => {
+    const rawValue = Array.isArray(lookbackMinutes) ? lookbackMinutes[0] : lookbackMinutes
+    const parsedValue = Number(rawValue)
+
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        return 0
+    }
+
+    return Math.min(MAX_LOOKBACK_MINUTES, Math.floor(parsedValue))
+}
+
 // Helper function to encapsulate main schedule logic
 const handleScheduleRequest = async (
     slug: string,
     filterMode: string,
     startDate: string | undefined,
     endDate: string | undefined,
+    lookbackMinutes: number,
     res: any,
     clientEtag: string | undefined
 ) => {
     // Generate cache key based on slug and filter parameters
-    const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}`
+    const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}-${lookbackMinutes}`
     const cachedEntry = scheduleCache.get(cacheKey)
     const now = Date.now()
     const isCurrentTimeDependent = requestDependsOnCurrentTime(filterMode, startDate, endDate)
@@ -574,7 +594,7 @@ const handleScheduleRequest = async (
     const getFilteredData = () => {
         switch (filterMode) {
             case 'next24hours':
-                return filterNext24Hours(scheduleData)
+                return filterNext24Hours(scheduleData, lookbackMinutes)
             case 'specificDate': {
                 if (!startDate) {
                     throw createError({
@@ -585,7 +605,7 @@ const handleScheduleRequest = async (
                 validateDateRange(scheduleData, startDate)
                 let filtered = filterByDate(scheduleData, startDate)
                 if (isToday(startDate)) {
-                    filtered = removePastEpisodes(filtered)
+                    filtered = removePastEpisodes(filtered, lookbackMinutes)
                 }
                 return filtered
             }
@@ -599,13 +619,13 @@ const handleScheduleRequest = async (
                 validateDateRange(scheduleData, startDate, endDate)
                 let filteredRange = filterByDateRange(scheduleData, startDate, endDate)
                 if (includesCurrentDate(startDate, endDate)) {
-                    filteredRange = removePastEpisodes(filteredRange)
+                    filteredRange = removePastEpisodes(filteredRange, lookbackMinutes)
                 }
                 return filteredRange
             }
             case 'all':
             default:
-                return removePastEpisodes(scheduleData)
+                return removePastEpisodes(scheduleData, lookbackMinutes)
         }
     }
 
@@ -636,6 +656,7 @@ export default defineEventHandler(async (event) => {
     const filterMode = (query?.filterMode as string) || 'all'
     const startDate = query?.startDate as string | undefined
     const endDate = query?.endDate as string | undefined
+    const lookbackMinutes = parseLookbackMinutes(query?.lookbackMinutes)
 
     if (!slug) {
         throw createError({
@@ -646,7 +667,7 @@ export default defineEventHandler(async (event) => {
 
     try {
         const clientEtag = event.node.req.headers['if-none-match']
-        return await handleScheduleRequest(slug, filterMode, startDate, endDate, res, clientEtag)
+        return await handleScheduleRequest(slug, filterMode, startDate, endDate, lookbackMinutes, res, clientEtag)
     } catch (error: any) {
         console.error('Error fetching schedule from S3:', error)
         throw createError({

--- a/server/api/schedule/[stationslug].get.ts
+++ b/server/api/schedule/[stationslug].get.ts
@@ -20,7 +20,7 @@
  * - filterMode: 'next24hours' | 'specificDate' | 'dateRange' | 'all' (default: 'all')
  * - startDate: (optional) ISO date string for filtering (YYYY-MM-DD) - interpreted in America/New_York timezone (EST/EDT)
  * - endDate: (optional) ISO date string for filtering (YYYY-MM-DD) - interpreted in America/New_York timezone (EST/EDT), used with dateRange mode
- * - lookbackMinutes: (optional) include recently-ended episodes for live metadata gap handling
+ * - includePreviousEpisode: (optional) include the most recently ended episode for live metadata gap handling
  * 
  * Timezone Handling:
  * - All date parameters are interpreted in America/New_York timezone (EST/EDT)
@@ -73,7 +73,6 @@ interface CacheEntry {
 
 const scheduleCache = new Map<string, CacheEntry>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes in milliseconds
-const MAX_LOOKBACK_MINUTES = 60
 
 // Transform v2 data structure to match old schedule endpoint format
 const normalizeSchedule = (scheduleData: any): any[] => {
@@ -241,26 +240,58 @@ const getScheduleFromS3 = async (bucketName: string, key: string) => {
     }
 }
 
-// Remove past episodes that have already aired
-const getLookbackStart = (now: Date, lookbackMinutes: number) => (
-    new Date(now.getTime() - Math.max(0, lookbackMinutes) * 60 * 1000)
-)
+function getEpisodeStartMs (episode: any) {
+    return new Date(episode.startTime).getTime()
+}
 
-const removePastEpisodes = (scheduleData: any, lookbackMinutes = 0) => {
+function getEpisodeEndMs (episode: any) {
+    return new Date(episode.endTime).getTime()
+}
+
+function getPreviousEpisode (episodes: any[], now: Date) {
+    const nowMs = now.getTime()
+    return [...episodes]
+        .filter((episode: any) => {
+            const endMs = getEpisodeEndMs(episode)
+            return Number.isFinite(endMs) && endMs <= nowMs
+        })
+        .sort((a: any, b: any) => getEpisodeEndMs(b) - getEpisodeEndMs(a))[0]
+}
+
+function includePreviousEpisodeIfRequested (
+    scheduleData: any,
+    filteredEpisodes: any[],
+    now: Date,
+    includePreviousEpisode: boolean
+) {
+    if (!includePreviousEpisode) {
+        return filteredEpisodes
+    }
+
+    const previousEpisode = getPreviousEpisode(scheduleData.episodes, now)
+    if (!previousEpisode || filteredEpisodes.includes(previousEpisode)) {
+        return filteredEpisodes
+    }
+
+    return [previousEpisode, ...filteredEpisodes]
+        .sort((a: any, b: any) => getEpisodeStartMs(a) - getEpisodeStartMs(b))
+}
+
+// Remove past episodes that have already aired
+function removePastEpisodes (scheduleData: any, includePreviousEpisode = false) {
     if (!scheduleData.episodes || !Array.isArray(scheduleData.episodes)) {
         return scheduleData
     }
 
     const now = new Date()
-    const lookbackStart = getLookbackStart(now, lookbackMinutes)
     const filteredEpisodes = scheduleData.episodes.filter((episode: any) => {
         const endTime = new Date(episode.endTime)
-        return endTime > lookbackStart
+        return endTime > now
     })
 
     return {
         ...scheduleData,
-        episodes: filteredEpisodes
+        episodes: includePreviousEpisodeIfRequested(scheduleData, filteredEpisodes, now, includePreviousEpisode)
     }
 }
 
@@ -281,25 +312,24 @@ const includesCurrentDate = (startDate: string, endDate: string): boolean => {
 }
 
 // Filter episodes for the next 24 hours
-const filterNext24Hours = (scheduleData: any, lookbackMinutes = 0) => {
+function filterNext24Hours (scheduleData: any, includePreviousEpisode = false) {
     if (!scheduleData.episodes || !Array.isArray(scheduleData.episodes)) {
         return scheduleData
     }
 
     const now = new Date()
-    const lookbackStart = getLookbackStart(now, lookbackMinutes)
     const next24Hours = new Date(now.getTime() + 24 * 60 * 60 * 1000)
 
     const filteredEpisodes = scheduleData.episodes.filter((episode: any) => {
         const startTime = new Date(episode.startTime)
         const endTime = new Date(episode.endTime)
         // Include episodes that start within the next 24 hours or are currently airing
-        return endTime > lookbackStart && startTime < next24Hours
+        return endTime > now && startTime < next24Hours
     })
 
     return {
         ...scheduleData,
-        episodes: filteredEpisodes
+        episodes: includePreviousEpisodeIfRequested(scheduleData, filteredEpisodes, now, includePreviousEpisode)
     }
 }
 
@@ -525,29 +555,18 @@ const setCacheHeaders = (res: any, etag: string, ttlMs: number) => {
     res.setHeader('Cache-Control', `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, must-revalidate`)
 }
 
-const parseLookbackMinutes = (lookbackMinutes: unknown) => {
-    const rawValue = Array.isArray(lookbackMinutes) ? lookbackMinutes[0] : lookbackMinutes
-    const parsedValue = Number(rawValue)
-
-    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
-        return 0
-    }
-
-    return Math.min(MAX_LOOKBACK_MINUTES, Math.floor(parsedValue))
-}
-
 // Helper function to encapsulate main schedule logic
 const handleScheduleRequest = async (
     slug: string,
     filterMode: string,
     startDate: string | undefined,
     endDate: string | undefined,
-    lookbackMinutes: number,
+    includePreviousEpisode: boolean,
     res: any,
     clientEtag: string | undefined
 ) => {
     // Generate cache key based on slug and filter parameters
-    const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}-${lookbackMinutes}`
+    const cacheKey = `${slug}-${filterMode}-${startDate || ''}-${endDate || ''}-${includePreviousEpisode}`
     const cachedEntry = scheduleCache.get(cacheKey)
     const now = Date.now()
     const isCurrentTimeDependent = requestDependsOnCurrentTime(filterMode, startDate, endDate)
@@ -594,7 +613,7 @@ const handleScheduleRequest = async (
     const getFilteredData = () => {
         switch (filterMode) {
             case 'next24hours':
-                return filterNext24Hours(scheduleData, lookbackMinutes)
+                return filterNext24Hours(scheduleData, includePreviousEpisode)
             case 'specificDate': {
                 if (!startDate) {
                     throw createError({
@@ -605,7 +624,7 @@ const handleScheduleRequest = async (
                 validateDateRange(scheduleData, startDate)
                 let filtered = filterByDate(scheduleData, startDate)
                 if (isToday(startDate)) {
-                    filtered = removePastEpisodes(filtered, lookbackMinutes)
+                    filtered = removePastEpisodes(filtered, includePreviousEpisode)
                 }
                 return filtered
             }
@@ -619,13 +638,13 @@ const handleScheduleRequest = async (
                 validateDateRange(scheduleData, startDate, endDate)
                 let filteredRange = filterByDateRange(scheduleData, startDate, endDate)
                 if (includesCurrentDate(startDate, endDate)) {
-                    filteredRange = removePastEpisodes(filteredRange, lookbackMinutes)
+                    filteredRange = removePastEpisodes(filteredRange, includePreviousEpisode)
                 }
                 return filteredRange
             }
             case 'all':
             default:
-                return removePastEpisodes(scheduleData, lookbackMinutes)
+                return removePastEpisodes(scheduleData, includePreviousEpisode)
         }
     }
 
@@ -656,7 +675,7 @@ export default defineEventHandler(async (event) => {
     const filterMode = (query?.filterMode as string) || 'all'
     const startDate = query?.startDate as string | undefined
     const endDate = query?.endDate as string | undefined
-    const lookbackMinutes = parseLookbackMinutes(query?.lookbackMinutes)
+    const includePreviousEpisode = query?.includePreviousEpisode === 'true'
 
     if (!slug) {
         throw createError({
@@ -667,7 +686,7 @@ export default defineEventHandler(async (event) => {
 
     try {
         const clientEtag = event.node.req.headers['if-none-match']
-        return await handleScheduleRequest(slug, filterMode, startDate, endDate, lookbackMinutes, res, clientEtag)
+        return await handleScheduleRequest(slug, filterMode, startDate, endDate, includePreviousEpisode, res, clientEtag)
     } catch (error: any) {
         console.error('Error fetching schedule from S3:', error)
         throw createError({

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -16,7 +16,7 @@ const config = useRuntimeConfig()
 import axios from 'axios'
 import humps from 'humps'
 import { useVImage } from '~/composables/useVImage'
-import { getCurrentEpisodeSelectionFromSchedule, LIVE_SCHEDULE_LOOKBACK_MINUTES } from '~/server/utils/liveSchedule'
+import { getCurrentEpisodeSelectionFromSchedule } from '~/server/utils/liveSchedule'
 
 interface LivestreamCacheEntry {
     data: any
@@ -81,7 +81,7 @@ const getLivestreams = async (slug?: string | null) => {
                 }
                 const stationImage = { cmsSource: 'publisher', template: metadata.imageLogo || templatizePublisherImageUrl(stream.image_logo), url: stream.image_logo }
                 // Fetch schedule data from the schedule API
-                const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&lookbackMinutes=${LIVE_SCHEDULE_LOOKBACK_MINUTES}`
+                const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&includePreviousEpisode=true`
                 const scheduleRes = await axios(scheduleUrl)
 
                 // Get the current episode from the schedule
@@ -147,7 +147,11 @@ const getLivestreams = async (slug?: string | null) => {
         const cacheUntilTimes = validResults
             .map((stream: any) => stream.cacheUntilMs)
             .filter((time: number) => Number.isFinite(time))
-        const data = validResults.map(({ cacheUntilMs, ...stream }: any) => stream)
+        const data = validResults.map((stream: any) => {
+            const streamData = { ...stream }
+            delete streamData.cacheUntilMs
+            return streamData
+        })
         const camelized = humps.camelizeKeys(data)
         // If a specific slug was requested, return the single object instead of an array
         return {
@@ -164,8 +168,8 @@ const getLivestreams = async (slug?: string | null) => {
  * Calculates a livestream cache TTL that expires at the next stream end time.
  */
 const getLivestreamCacheTtl = (streams: any, nowMs = Date.now(), cacheUntilMs?: number | null) => {
-    if (Number.isFinite(cacheUntilMs) && cacheUntilMs! > nowMs) {
-        return Math.max(0, Math.min(LIVESTREAM_CACHE_TTL, cacheUntilMs! - nowMs))
+    if (typeof cacheUntilMs === 'number' && Number.isFinite(cacheUntilMs) && cacheUntilMs > nowMs) {
+        return Math.max(0, Math.min(LIVESTREAM_CACHE_TTL, cacheUntilMs - nowMs))
     }
 
     const streamArray = Array.isArray(streams) ? streams : [streams]

--- a/server/api/streams.ts
+++ b/server/api/streams.ts
@@ -16,6 +16,7 @@ const config = useRuntimeConfig()
 import axios from 'axios'
 import humps from 'humps'
 import { useVImage } from '~/composables/useVImage'
+import { getCurrentEpisodeSelectionFromSchedule, LIVE_SCHEDULE_LOOKBACK_MINUTES } from '~/server/utils/liveSchedule'
 
 interface LivestreamCacheEntry {
     data: any
@@ -53,24 +54,6 @@ const STATION_METADATA = {
     },
 }
 
-// Helper function to get the current episode from schedule data
-const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
-    if (!scheduleData || !Array.isArray(scheduleData)) {
-        return null
-    }
-
-    const now = new Date()
-
-    // Find the episode that is currently airing
-    const currentEpisode = scheduleData.find((episode: any) => {
-        const startTime = new Date(episode.attributes.start)
-        const endTime = new Date(episode.attributes.end)
-        return now >= startTime && now < endTime
-    })
-
-    return currentEpisode || scheduleData[0] // Fallback to first episode if no current match
-}
-
 // currently a combination between the whatson API and the schedule API to populate the live stream data
 const getLivestreams = async (slug?: string | null) => {
     try {
@@ -98,11 +81,12 @@ const getLivestreams = async (slug?: string | null) => {
                 }
                 const stationImage = { cmsSource: 'publisher', template: metadata.imageLogo || templatizePublisherImageUrl(stream.image_logo), url: stream.image_logo }
                 // Fetch schedule data from the schedule API
-                const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours`
+                const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&lookbackMinutes=${LIVE_SCHEDULE_LOOKBACK_MINUTES}`
                 const scheduleRes = await axios(scheduleUrl)
 
                 // Get the current episode from the schedule
-                const currentEpisode = getCurrentEpisodeFromSchedule(scheduleRes.data)
+                const currentEpisodeSelection = getCurrentEpisodeSelectionFromSchedule(scheduleRes.data)
+                const currentEpisode = currentEpisodeSelection?.episode
 
                 if (!currentEpisode) {
                     return null
@@ -149,7 +133,8 @@ const getLivestreams = async (slug?: string | null) => {
                     showSchedule: {
                         'iso-start-time': attrs.start,
                         'iso-end-time': attrs.end,
-                    }
+                    },
+                    cacheUntilMs: currentEpisodeSelection.cacheUntilMs,
                 }
             } catch (err: any) {
                 console.error('Error in scheduleUrl fetch:', err)
@@ -159,9 +144,16 @@ const getLivestreams = async (slug?: string | null) => {
 
         // Filter out any null results from failed fetches
         const validResults = resData.filter(Boolean)
-        const camelized = humps.camelizeKeys(validResults)
+        const cacheUntilTimes = validResults
+            .map((stream: any) => stream.cacheUntilMs)
+            .filter((time: number) => Number.isFinite(time))
+        const data = validResults.map(({ cacheUntilMs, ...stream }: any) => stream)
+        const camelized = humps.camelizeKeys(data)
         // If a specific slug was requested, return the single object instead of an array
-        return slug ? (camelized[0] ?? null) : camelized
+        return {
+            data: slug ? (camelized[0] ?? null) : camelized,
+            cacheUntilMs: cacheUntilTimes.length ? Math.min(...cacheUntilTimes) : null,
+        }
     } catch (e) {
         console.error('Error in getLivestreams:', e)
     }
@@ -171,7 +163,11 @@ const getLivestreams = async (slug?: string | null) => {
 /**
  * Calculates a livestream cache TTL that expires at the next stream end time.
  */
-const getLivestreamCacheTtl = (streams: any, nowMs = Date.now()) => {
+const getLivestreamCacheTtl = (streams: any, nowMs = Date.now(), cacheUntilMs?: number | null) => {
+    if (Number.isFinite(cacheUntilMs) && cacheUntilMs! > nowMs) {
+        return Math.max(0, Math.min(LIVESTREAM_CACHE_TTL, cacheUntilMs! - nowMs))
+    }
+
     const streamArray = Array.isArray(streams) ? streams : [streams]
     const endTimes = streamArray
         .map((stream: any) => stream?.timeEnd)
@@ -215,8 +211,9 @@ export default defineEventHandler(async (event) => {
         return cachedEntry.data
     }
 
-    const streams = await getLivestreams(slug)
-    const cacheTtl = getLivestreamCacheTtl(streams, now)
+    const livestreamResult = await getLivestreams(slug)
+    const streams = livestreamResult?.data ?? null
+    const cacheTtl = getLivestreamCacheTtl(streams, now, livestreamResult?.cacheUntilMs)
 
     if (cacheTtl > 0) {
         livestreamCache.set(cacheKey, {

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -15,7 +15,7 @@
 import axios from 'axios'
 import humps from 'humps'
 import { cmsSources } from '~/composables/globals'
-import { getCurrentEpisodeSelectionFromSchedule, LIVE_SCHEDULE_LOOKBACK_MINUTES } from '~/server/utils/liveSchedule'
+import { getCurrentEpisodeSelectionFromSchedule } from '~/server/utils/liveSchedule'
 
 const config = useRuntimeConfig()
 
@@ -74,7 +74,7 @@ const getLivestream = async (slug: string) => {
 		}
 		
 		// Fetch schedule data from the schedule API
-		const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&lookbackMinutes=${LIVE_SCHEDULE_LOOKBACK_MINUTES}`
+		const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&includePreviousEpisode=true`
 		const scheduleRes = await axios(scheduleUrl)
 		
 		// Get the current episode from the schedule
@@ -152,8 +152,8 @@ const getLivestream = async (slug: string) => {
  * Calculates a whats-on cache TTL that expires when the current item ends.
  */
 const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now(), cacheUntilMs?: number | null) => {
-	if (Number.isFinite(cacheUntilMs) && cacheUntilMs! > nowMs) {
-		return Math.max(0, Math.min(WHATSON_CACHE_TTL, cacheUntilMs! - nowMs))
+	if (typeof cacheUntilMs === 'number' && Number.isFinite(cacheUntilMs) && cacheUntilMs > nowMs) {
+		return Math.max(0, Math.min(WHATSON_CACHE_TTL, cacheUntilMs - nowMs))
 	}
 
 	const endTime = new Date(livestream?.timeEnd).getTime()

--- a/server/api/whatson/[stationslug].ts
+++ b/server/api/whatson/[stationslug].ts
@@ -15,6 +15,7 @@
 import axios from 'axios'
 import humps from 'humps'
 import { cmsSources } from '~/composables/globals'
+import { getCurrentEpisodeSelectionFromSchedule, LIVE_SCHEDULE_LOOKBACK_MINUTES } from '~/server/utils/liveSchedule'
 
 const config = useRuntimeConfig()
 
@@ -62,24 +63,6 @@ const templatizeImageUrl = (url: string) => {
     return `https://media.wnyc.org/i/%s/%s/%s/%s/${filename}`
 }
 
-// Helper function to get the current episode from schedule data
-const getCurrentEpisodeFromSchedule = (scheduleData: any) => {
-    if (!scheduleData || !Array.isArray(scheduleData)) {
-        return null
-    }
-    
-    const now = new Date()
-    
-    // Find the episode that is currently airing
-    const currentEpisode = scheduleData.find((episode: any) => {
-        const startTime = new Date(episode.attributes.start)
-        const endTime = new Date(episode.attributes.end)
-        return now >= startTime && now < endTime
-    })
-    
-    return currentEpisode || scheduleData[0] // Fallback to first episode if no current match
-}
-
 // Fetch the livestream data from the Schedule API
 const getLivestream = async (slug: string) => {
 	try {
@@ -91,11 +74,12 @@ const getLivestream = async (slug: string) => {
 		}
 		
 		// Fetch schedule data from the schedule API
-		const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours`
+		const scheduleUrl = `${config.public.BFF_URL}/api/schedule/${slug}?filterMode=next24hours&lookbackMinutes=${LIVE_SCHEDULE_LOOKBACK_MINUTES}`
 		const scheduleRes = await axios(scheduleUrl)
 		
 		// Get the current episode from the schedule
-		const currentEpisode = getCurrentEpisodeFromSchedule(scheduleRes.data)
+		const currentEpisodeSelection = getCurrentEpisodeSelectionFromSchedule(scheduleRes.data)
+		const currentEpisode = currentEpisodeSelection?.episode
 		
 		if (!currentEpisode) {
 			console.warn(`No current episode found for ${slug}`)
@@ -154,7 +138,10 @@ const getLivestream = async (slug: string) => {
 			}
 		}
 		
-		return humps.camelizeKeys(formattedData)
+		return {
+			data: humps.camelizeKeys(formattedData),
+			cacheUntilMs: currentEpisodeSelection.cacheUntilMs,
+		}
 	} catch (error) {
 		console.error(`Error fetching schedule data for ${slug}:`, error.message)
 		throw error
@@ -164,7 +151,11 @@ const getLivestream = async (slug: string) => {
 /**
  * Calculates a whats-on cache TTL that expires when the current item ends.
  */
-const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now()) => {
+const getWhatsOnCacheTtl = (livestream: any, nowMs = Date.now(), cacheUntilMs?: number | null) => {
+	if (Number.isFinite(cacheUntilMs) && cacheUntilMs! > nowMs) {
+		return Math.max(0, Math.min(WHATSON_CACHE_TTL, cacheUntilMs! - nowMs))
+	}
+
 	const endTime = new Date(livestream?.timeEnd).getTime()
 	if (!Number.isFinite(endTime) || endTime <= nowMs) {
 		return 0
@@ -240,8 +231,9 @@ export default defineEventHandler(async (event) => {
 				return cachedEntry.data
 			}
 
-			const livestream = await getLivestream(slug);
-			const cacheTtl = getWhatsOnCacheTtl(livestream, now)
+			const livestreamResult = await getLivestream(slug);
+			const livestream = livestreamResult.data
+			const cacheTtl = getWhatsOnCacheTtl(livestream, now, livestreamResult.cacheUntilMs)
 
 			if (cacheTtl > 0) {
 				whatsOnCache.set(slug, {

--- a/server/utils/liveSchedule.ts
+++ b/server/utils/liveSchedule.ts
@@ -1,7 +1,3 @@
-export const LIVE_SCHEDULE_LOOKBACK_MINUTES = 15
-
-const LIVE_SCHEDULE_LOOKBACK_MS = LIVE_SCHEDULE_LOOKBACK_MINUTES * 60 * 1000
-
 type ScheduleEpisode = {
     attributes?: {
         start?: string
@@ -14,19 +10,23 @@ type CurrentEpisodeSelection = {
     cacheUntilMs: number | null
 }
 
-const getEpisodeStartMs = (episode: ScheduleEpisode) => new Date(episode?.attributes?.start || '').getTime()
-const getEpisodeEndMs = (episode: ScheduleEpisode) => new Date(episode?.attributes?.end || '').getTime()
+function getEpisodeStartMs (episode: ScheduleEpisode) {
+    return new Date(episode?.attributes?.start || '').getTime()
+}
 
-const hasValidTimes = (episode: ScheduleEpisode) => (
-    Number.isFinite(getEpisodeStartMs(episode)) &&
-    Number.isFinite(getEpisodeEndMs(episode))
-)
+function getEpisodeEndMs (episode: ScheduleEpisode) {
+    return new Date(episode?.attributes?.end || '').getTime()
+}
 
-export const getCurrentEpisodeSelectionFromSchedule = (
+function hasValidTimes (episode: ScheduleEpisode) {
+    return Number.isFinite(getEpisodeStartMs(episode)) &&
+        Number.isFinite(getEpisodeEndMs(episode))
+}
+
+export function getCurrentEpisodeSelectionFromSchedule (
     scheduleData: ScheduleEpisode[] | null | undefined,
-    now = new Date(),
-    gapGraceMs = LIVE_SCHEDULE_LOOKBACK_MS
-): CurrentEpisodeSelection | null => {
+    now = new Date()
+): CurrentEpisodeSelection | null {
     if (!Array.isArray(scheduleData)) {
         return null
     }
@@ -52,42 +52,26 @@ export const getCurrentEpisodeSelectionFromSchedule = (
     const previousEpisode = [...episodes].reverse().find((episode) => getEpisodeEndMs(episode) <= nowMs)
     const nextEpisode = episodes.find((episode) => getEpisodeStartMs(episode) > nowMs)
 
-    if (previousEpisode && nextEpisode) {
-        const previousEndMs = getEpisodeEndMs(previousEpisode)
-        const nextStartMs = getEpisodeStartMs(nextEpisode)
-        const gapMs = nextStartMs - previousEndMs
-
-        if (nowMs >= previousEndMs && nowMs < nextStartMs && gapMs > 0 && gapMs <= gapGraceMs) {
-            return {
-                episode: previousEpisode,
-                cacheUntilMs: nextStartMs,
-            }
-        }
-    }
-
     if (previousEpisode) {
-        const previousEndMs = getEpisodeEndMs(previousEpisode)
-        if (nowMs - previousEndMs <= gapGraceMs) {
-            return {
-                episode: previousEpisode,
-                cacheUntilMs: null,
-            }
+        return {
+            episode: previousEpisode,
+            cacheUntilMs: nextEpisode ? getEpisodeStartMs(nextEpisode) : null,
         }
     }
 
     if (nextEpisode) {
-        const nextStartMs = getEpisodeStartMs(nextEpisode)
         return {
             episode: nextEpisode,
-            cacheUntilMs: nextStartMs > nowMs ? nextStartMs : getEpisodeEndMs(nextEpisode),
+            cacheUntilMs: getEpisodeStartMs(nextEpisode),
         }
     }
 
     return null
 }
 
-export const getCurrentEpisodeFromSchedule = (
+export function getCurrentEpisodeFromSchedule (
     scheduleData: ScheduleEpisode[] | null | undefined,
-    now = new Date(),
-    gapGraceMs = LIVE_SCHEDULE_LOOKBACK_MS
-) => getCurrentEpisodeSelectionFromSchedule(scheduleData, now, gapGraceMs)?.episode ?? null
+    now = new Date()
+) {
+    return getCurrentEpisodeSelectionFromSchedule(scheduleData, now)?.episode ?? null
+}

--- a/server/utils/liveSchedule.ts
+++ b/server/utils/liveSchedule.ts
@@ -1,0 +1,93 @@
+export const LIVE_SCHEDULE_LOOKBACK_MINUTES = 15
+
+const LIVE_SCHEDULE_LOOKBACK_MS = LIVE_SCHEDULE_LOOKBACK_MINUTES * 60 * 1000
+
+type ScheduleEpisode = {
+    attributes?: {
+        start?: string
+        end?: string
+    }
+}
+
+type CurrentEpisodeSelection = {
+    episode: ScheduleEpisode
+    cacheUntilMs: number | null
+}
+
+const getEpisodeStartMs = (episode: ScheduleEpisode) => new Date(episode?.attributes?.start || '').getTime()
+const getEpisodeEndMs = (episode: ScheduleEpisode) => new Date(episode?.attributes?.end || '').getTime()
+
+const hasValidTimes = (episode: ScheduleEpisode) => (
+    Number.isFinite(getEpisodeStartMs(episode)) &&
+    Number.isFinite(getEpisodeEndMs(episode))
+)
+
+export const getCurrentEpisodeSelectionFromSchedule = (
+    scheduleData: ScheduleEpisode[] | null | undefined,
+    now = new Date(),
+    gapGraceMs = LIVE_SCHEDULE_LOOKBACK_MS
+): CurrentEpisodeSelection | null => {
+    if (!Array.isArray(scheduleData)) {
+        return null
+    }
+
+    const nowMs = now.getTime()
+    const episodes = scheduleData
+        .filter(hasValidTimes)
+        .sort((a, b) => getEpisodeStartMs(a) - getEpisodeStartMs(b))
+
+    const currentEpisode = episodes.find((episode) => {
+        const startMs = getEpisodeStartMs(episode)
+        const endMs = getEpisodeEndMs(episode)
+        return nowMs >= startMs && nowMs < endMs
+    })
+
+    if (currentEpisode) {
+        return {
+            episode: currentEpisode,
+            cacheUntilMs: getEpisodeEndMs(currentEpisode),
+        }
+    }
+
+    const previousEpisode = [...episodes].reverse().find((episode) => getEpisodeEndMs(episode) <= nowMs)
+    const nextEpisode = episodes.find((episode) => getEpisodeStartMs(episode) > nowMs)
+
+    if (previousEpisode && nextEpisode) {
+        const previousEndMs = getEpisodeEndMs(previousEpisode)
+        const nextStartMs = getEpisodeStartMs(nextEpisode)
+        const gapMs = nextStartMs - previousEndMs
+
+        if (nowMs >= previousEndMs && nowMs < nextStartMs && gapMs > 0 && gapMs <= gapGraceMs) {
+            return {
+                episode: previousEpisode,
+                cacheUntilMs: nextStartMs,
+            }
+        }
+    }
+
+    if (previousEpisode) {
+        const previousEndMs = getEpisodeEndMs(previousEpisode)
+        if (nowMs - previousEndMs <= gapGraceMs) {
+            return {
+                episode: previousEpisode,
+                cacheUntilMs: null,
+            }
+        }
+    }
+
+    if (nextEpisode) {
+        const nextStartMs = getEpisodeStartMs(nextEpisode)
+        return {
+            episode: nextEpisode,
+            cacheUntilMs: nextStartMs > nowMs ? nextStartMs : getEpisodeEndMs(nextEpisode),
+        }
+    }
+
+    return null
+}
+
+export const getCurrentEpisodeFromSchedule = (
+    scheduleData: ScheduleEpisode[] | null | undefined,
+    now = new Date(),
+    gapGraceMs = LIVE_SCHEDULE_LOOKBACK_MS
+) => getCurrentEpisodeSelectionFromSchedule(scheduleData, now, gapGraceMs)?.episode ?? null

--- a/tests/server/live-schedule.spec.ts
+++ b/tests/server/live-schedule.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { getCurrentEpisodeSelectionFromSchedule } from '../../server/utils/liveSchedule'
+
+const episode = (id: string, start: string, end: string) => ({
+  id,
+  attributes: {
+    start,
+    end,
+    parentTitle: id,
+  },
+})
+
+describe('live schedule episode selection', () => {
+  it('keeps the just-ended episode during a short schedule gap', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [
+        episode('Morning Edition', '2026-04-28T11:00:00Z', '2026-04-28T12:50:00Z'),
+        episode('BBC World Service', '2026-04-28T13:00:00Z', '2026-04-28T13:59:00Z'),
+      ],
+      new Date('2026-04-28T12:54:00Z')
+    )
+
+    expect(selection?.episode.id).toBe('Morning Edition')
+    expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:00:00Z').getTime())
+  })
+
+  it('switches to the next episode once it actually starts', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [
+        episode('Morning Edition', '2026-04-28T11:00:00Z', '2026-04-28T12:50:00Z'),
+        episode('BBC World Service', '2026-04-28T13:00:00Z', '2026-04-28T13:59:00Z'),
+      ],
+      new Date('2026-04-28T13:00:00Z')
+    )
+
+    expect(selection?.episode.id).toBe('BBC World Service')
+    expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:59:00Z').getTime())
+  })
+
+  it('does not bridge long gaps', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [
+        episode('Previous Show', '2026-04-28T10:00:00Z', '2026-04-28T11:00:00Z'),
+        episode('Next Show', '2026-04-28T13:00:00Z', '2026-04-28T14:00:00Z'),
+      ],
+      new Date('2026-04-28T12:54:00Z')
+    )
+
+    expect(selection?.episode.id).toBe('Next Show')
+    expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:00:00Z').getTime())
+  })
+})

--- a/tests/server/live-schedule.spec.ts
+++ b/tests/server/live-schedule.spec.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { getCurrentEpisodeSelectionFromSchedule } from '../../server/utils/liveSchedule'
 
-const episode = (id: string, start: string, end: string) => ({
-  id,
-  attributes: {
-    start,
-    end,
-    parentTitle: id,
-  },
-})
+function episode (id: string, start: string, end: string) {
+  return {
+    id,
+    attributes: {
+      start,
+      end,
+      parentTitle: id,
+    },
+  }
+}
 
 describe('live schedule episode selection', () => {
   it('keeps the just-ended episode during a short schedule gap', () => {
@@ -37,7 +39,7 @@ describe('live schedule episode selection', () => {
     expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:59:00Z').getTime())
   })
 
-  it('does not bridge long gaps', () => {
+  it('keeps the previous episode during a long schedule gap', () => {
     const selection = getCurrentEpisodeSelectionFromSchedule(
       [
         episode('Previous Show', '2026-04-28T10:00:00Z', '2026-04-28T11:00:00Z'),
@@ -46,7 +48,42 @@ describe('live schedule episode selection', () => {
       new Date('2026-04-28T12:54:00Z')
     )
 
-    expect(selection?.episode.id).toBe('Next Show')
+    expect(selection?.episode.id).toBe('Previous Show')
     expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:00:00Z').getTime())
+  })
+
+  it('returns the currently airing episode when one exists', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [
+        episode('Previous Show', '2026-04-28T10:00:00Z', '2026-04-28T11:00:00Z'),
+        episode('Current Show', '2026-04-28T12:00:00Z', '2026-04-28T13:00:00Z'),
+        episode('Next Show', '2026-04-28T13:00:00Z', '2026-04-28T14:00:00Z'),
+      ],
+      new Date('2026-04-28T12:30:00Z')
+    )
+
+    expect(selection?.episode.id).toBe('Current Show')
+    expect(selection?.cacheUntilMs).toBe(new Date('2026-04-28T13:00:00Z').getTime())
+  })
+
+  it('returns null for an empty schedule', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [],
+      new Date('2026-04-28T12:30:00Z')
+    )
+
+    expect(selection).toBeNull()
+  })
+
+  it('keeps the previous episode with no cache boundary when no next episode exists', () => {
+    const selection = getCurrentEpisodeSelectionFromSchedule(
+      [
+        episode('Previous Show', '2026-04-28T10:00:00Z', '2026-04-28T11:00:00Z'),
+      ],
+      new Date('2026-04-28T12:30:00Z')
+    )
+
+    expect(selection?.episode.id).toBe('Previous Show')
+    expect(selection?.cacheUntilMs).toBeNull()
   })
 })


### PR DESCRIPTION
Updates live schedule metadata selection so `/api/streams` and `/api/whatson` keep showing the most recently ended show during schedule gaps instead of falling forward to the next future show. The schedule endpoint can now include the previous episode for live metadata callers, and the live/what's-on caches expire at the next real schedule boundary so surfaces switch when the next show actually starts. Adds focused coverage for current-show, gap, boundary, empty, and previous-only schedule cases.