### PR TITLE
Fix CMS redirects under story and show paths

### DIFF
--- a/pages/browse/shows/[slug]/episodes.vue
+++ b/pages/browse/shows/[slug]/episodes.vue
@@ -30,6 +30,13 @@ const {
   }
 )
 
+if (show.value?.redirect) {
+  await navigateTo(show.value.location, {
+    redirectCode: show.value.statusCode || 301,
+    external: /^https?:\/\//.test(show.value.location),
+  })
+}
+
 const podcastId = computed(
   () => show.value?.linkedDataSource?.[0]?.value?.id ?? null
 )

--- a/pages/browse/shows/[slug]/index.vue
+++ b/pages/browse/shows/[slug]/index.vue
@@ -19,6 +19,13 @@ const { data: show, status, error } = isApp.value
   ? useFetchWrapper(...showFetchArgs)
   : await useFetchWrapper(...showFetchArgs)
 
+if (show.value?.redirect) {
+  await navigateTo(show.value.location, {
+    redirectCode: show.value.statusCode || 301,
+    external: /^https?:\/\//.test(show.value.location),
+  })
+}
+
 // Auto-refresh handled by useFetchWrapper
 
 const sectionAnchorData = computed(

--- a/pages/browse/shows/[slug]/index.vue
+++ b/pages/browse/shows/[slug]/index.vue
@@ -19,12 +19,20 @@ const { data: show, status, error } = isApp.value
   ? useFetchWrapper(...showFetchArgs)
   : await useFetchWrapper(...showFetchArgs)
 
-if (show.value?.redirect) {
-  await navigateTo(show.value.location, {
-    redirectCode: show.value.statusCode || 301,
-    external: /^https?:\/\//.test(show.value.location),
+const redirectIfNeeded = (page) => {
+  if (!page?.redirect) return
+
+  return navigateTo(page.location, {
+    redirectCode: page.statusCode || 301,
+    external: /^https?:\/\//.test(page.location),
   })
 }
+
+watch(show, (page) => {
+  redirectIfNeeded(page)
+})
+
+await redirectIfNeeded(show.value)
 
 // Auto-refresh handled by useFetchWrapper
 

--- a/pages/story/[slug]/index.vue
+++ b/pages/story/[slug]/index.vue
@@ -35,6 +35,13 @@ const filteredTopStories = computed(() =>
   getFilteredTopStories(storyData.value)
 )
 
+if (storyData.value?.redirect) {
+  await navigateTo(storyData.value.location, {
+    redirectCode: storyData.value.statusCode || 301,
+    external: /^https?:\/\//.test(storyData.value.location),
+  })
+}
+
 onMounted(() => {
   if (!storyData.value) return
   const { $analytics } = useNuxtApp()

--- a/server/api/pages/[cmsSource]/[pageSlug].ts
+++ b/server/api/pages/[cmsSource]/[pageSlug].ts
@@ -3,6 +3,7 @@ import humps from 'humps'
 import { cmsSources, mediaTypeRoutes } from '~/composables/globals'
 import { normalizeArticlePage } from '~/composables/data/articlePages'
 import { transformCuratedContent } from '~/utilities/curatedContent'
+import { getCmsPathRedirect, getCmsRequestOptions } from '~/server/utils/cmsRedirect'
 
 // Helper to obtain runtime config, with test override support.
 const __getConfig = () => {
@@ -65,6 +66,19 @@ const getWagtailPageData = async (pageSlug: string, isShowOnly?: boolean, isDown
         return await normalizeArticlePage(resData)
     } catch (error: any) {
         if (error?.response?.status === 404) {
+            const requestOptions = getCmsRequestOptions(config.public.cmsSite)
+            const redirectPaths = [
+                `${mediaTypeRoutes.show}${pageSlug}`,
+                `/shows/${pageSlug}`,
+            ]
+
+            for (const path of redirectPaths) {
+                const redirect = await getCmsPathRedirect(config.public.AVIARY_BASE_API, path, requestOptions)
+                if (redirect) {
+                    return redirect
+                }
+            }
+
             // Nuxt expects proper error objects to avoid generic 500 noise
             throw createError({ statusCode: 404, statusMessage: `Page not found: ${pageSlug}` })
         }

--- a/server/api/pages/[cmsSource]/[pageSlug].ts
+++ b/server/api/pages/[cmsSource]/[pageSlug].ts
@@ -11,6 +11,29 @@ const __getConfig = () => {
     return testCfg ?? useRuntimeConfig()
 }
 
+const isWnycHost = (hostname: string) => hostname === 'wnyc.org' || hostname.endsWith('.wnyc.org')
+
+const routeLegacyShowLocation = (location: string) => {
+    const routedShowPrefix = mediaTypeRoutes.show.replace(/\/$/, '')
+    const rewritePath = (path: string) => path.replace(/^\/shows(?=\/|$)/, routedShowPrefix)
+
+    if (location.startsWith('/shows/') || location === '/shows') {
+        return rewritePath(location)
+    }
+
+    try {
+        const url = new URL(location)
+
+        if (!isWnycHost(url.hostname) || !(url.pathname.startsWith('/shows/') || url.pathname === '/shows')) {
+            return location
+        }
+
+        return `${rewritePath(url.pathname)}${url.search}${url.hash}`
+    } catch {
+        return location
+    }
+}
+
 // getting flat page data from the publisher api
 const getPublisherPageData = async (pageSlug: string) => {
     const config = __getConfig()
@@ -75,7 +98,10 @@ const getWagtailPageData = async (pageSlug: string, isShowOnly?: boolean, isDown
             for (const path of redirectPaths) {
                 const redirect = await getCmsPathRedirect(config.public.AVIARY_BASE_API, path, requestOptions)
                 if (redirect) {
-                    return redirect
+                    return {
+                        ...redirect,
+                        location: routeLegacyShowLocation(redirect.location),
+                    }
                 }
             }
 

--- a/server/api/story/[cmsSource]/[storyId].ts
+++ b/server/api/story/[cmsSource]/[storyId].ts
@@ -33,9 +33,10 @@ const getCmsRedirectForStoryPath = async (slug: string) => {
 }
 
 const getPublisherStoryData = async (idOrSlug: string) => {
+    const isNumericId = /^\d+$/.test(idOrSlug);
+
     try {
         // Determine if the identifier is numeric (ID) or a slug
-        const isNumericId = /^\d+$/.test(idOrSlug);
         const endpoint = isNumericId 
             ? `v3/story-pk/${idOrSlug}/`
             : `v3/story/${idOrSlug}/`;
@@ -49,7 +50,9 @@ const getPublisherStoryData = async (idOrSlug: string) => {
     } catch (e: any) {
 
         if (e.response && e.response.status === 404) {
-            return await getCmsRedirectForStoryPath(idOrSlug)
+            if (!isNumericId) {
+                return await getCmsRedirectForStoryPath(idOrSlug)
+            }
         } else {
             console.error(e);
         }

--- a/server/api/story/[cmsSource]/[storyId].ts
+++ b/server/api/story/[cmsSource]/[storyId].ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import humps from 'humps'
 import { normalizePublisherPage, normalizeWagtailPage } from '~/composables/data/articlePages'
+import { getCmsPathRedirect, getCmsRequestOptions } from '~/server/utils/cmsRedirect'
 
 const config = useRuntimeConfig();
 
@@ -17,11 +18,19 @@ const getWagtailStoryData = async (id: string) => {
         //return humps.camelizeKeys(res.data);
 
         return normalizeWagtailPage(humps.camelizeKeys(res.data));
-    } catch (e) {
+    } catch (e: any) {
+        if (e?.response?.status === 404) {
+            return await getCmsRedirectForStoryPath(id)
+        }
         //console.log(e);
     }
     return null
 };
+
+const getCmsRedirectForStoryPath = async (slug: string) => {
+    const requestOptions = getCmsRequestOptions(config.public.cmsSite)
+    return await getCmsPathRedirect(config.public.AVIARY_BASE_API, `/story/${slug}`, requestOptions)
+}
 
 const getPublisherStoryData = async (idOrSlug: string) => {
     try {
@@ -37,10 +46,10 @@ const getPublisherStoryData = async (idOrSlug: string) => {
         };
         const res = await axios(option);
         return normalizePublisherPage(humps.camelizeKeys(res.data).data);
-    } catch (e) {
+    } catch (e: any) {
 
         if (e.response && e.response.status === 404) {
-            console.error('404 = ', e)
+            return await getCmsRedirectForStoryPath(idOrSlug)
         } else {
             console.error(e);
         }

--- a/server/utils/cmsRedirect.ts
+++ b/server/utils/cmsRedirect.ts
@@ -56,13 +56,13 @@ export const getCmsPathRedirect = async (
   requestOptions: ReturnType<typeof getCmsRequestOptions>
 ) => {
   const redirectUrl = getCmsPathUrl(baseApi, path)
-  let redirectRes = await axios.get(redirectUrl, requestOptions)
+  let redirectRes = await axios.head(redirectUrl, requestOptions)
 
   if (redirectRes.status >= 300 && redirectRes.status < 400) {
     const location = redirectRes.headers?.location
 
     if (location && isSlashNormalizationRedirect(redirectUrl, location)) {
-      redirectRes = await axios.get(new URL(location, redirectUrl).toString(), requestOptions)
+      redirectRes = await axios.head(new URL(location, redirectUrl).toString(), requestOptions)
     }
   }
 

--- a/server/utils/cmsRedirect.ts
+++ b/server/utils/cmsRedirect.ts
@@ -1,0 +1,74 @@
+import axios from 'axios'
+import { createError } from 'h3'
+
+export const getCmsRequestOptions = (cmsSite: string) => ({
+  headers: {
+    'X-CMS-Site': cmsSite,
+  },
+  maxRedirects: 0,
+  validateStatus: () => true,
+})
+
+export const normalizeCmsLocation = (location: string, baseApi: string) => {
+  const base = new URL(baseApi)
+  const absolute = new URL(location, base)
+
+  // Force the origin to match the CMS API host so we don't follow redirects
+  // to a placeholder site domain.
+  absolute.protocol = base.protocol
+  absolute.host = base.host
+
+  return absolute.toString()
+}
+
+export const getCmsPathUrl = (baseApi: string, path: string) => {
+  const base = new URL(baseApi)
+  return new URL(path, base.origin).toString()
+}
+
+const stripTrailingSlash = (path: string) => path.replace(/\/+$/, '') || '/'
+
+const isSlashNormalizationRedirect = (fromUrl: string, location: string) => {
+  const from = new URL(fromUrl)
+  const to = new URL(location, from)
+
+  return (
+    from.origin === to.origin &&
+    stripTrailingSlash(from.pathname) === stripTrailingSlash(to.pathname)
+  )
+}
+
+export const redirectResponse = (status: number, location?: string) => {
+  if (!location) {
+    throw createError({ statusCode: 502, statusMessage: 'CMS redirect missing location header' })
+  }
+
+  return {
+    redirect: true,
+    location,
+    statusCode: status,
+  }
+}
+
+export const getCmsPathRedirect = async (
+  baseApi: string,
+  path: string,
+  requestOptions: ReturnType<typeof getCmsRequestOptions>
+) => {
+  const redirectUrl = getCmsPathUrl(baseApi, path)
+  let redirectRes = await axios.get(redirectUrl, requestOptions)
+
+  if (redirectRes.status >= 300 && redirectRes.status < 400) {
+    const location = redirectRes.headers?.location
+
+    if (location && isSlashNormalizationRedirect(redirectUrl, location)) {
+      redirectRes = await axios.get(new URL(location, redirectUrl).toString(), requestOptions)
+    }
+  }
+
+  if (redirectRes.status >= 300 && redirectRes.status < 400) {
+    return redirectResponse(redirectRes.status, redirectRes.headers?.location)
+  }
+
+  return null
+}

--- a/server/utils/cmsRedirect.ts
+++ b/server/utils/cmsRedirect.ts
@@ -3,6 +3,7 @@ import { createError } from 'h3'
 
 export const getCmsRequestOptions = (cmsSite: string) => ({
   headers: {
+    'Accept-Encoding': 'identity',
     'X-CMS-Site': cmsSite,
   },
   maxRedirects: 0,

--- a/server/utils/cmsRedirect.ts
+++ b/server/utils/cmsRedirect.ts
@@ -62,8 +62,12 @@ export const getCmsPathRedirect = async (
   if (redirectRes.status >= 300 && redirectRes.status < 400) {
     const location = redirectRes.headers?.location
 
-    if (location && isSlashNormalizationRedirect(redirectUrl, location)) {
-      redirectRes = await axios.head(new URL(location, redirectUrl).toString(), requestOptions)
+    if (location) {
+      const nextUrl = normalizeCmsLocation(location, baseApi)
+
+      if (isSlashNormalizationRedirect(redirectUrl, nextUrl)) {
+        redirectRes = await axios.head(nextUrl, requestOptions)
+      }
     }
   }
 

--- a/tests/server/cms-route-redirects.spec.ts
+++ b/tests/server/cms-route-redirects.spec.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const axiosMock = vi.fn()
+const axiosGetMock = vi.fn()
+axiosMock.get = axiosGetMock
+
+vi.mock('axios', () => ({
+  default: axiosMock,
+}))
+
+vi.mock('h3', () => ({
+  createError: (options: any) => Object.assign(new Error(options.statusMessage), options),
+}))
+
+vi.mock('~/composables/globals', () => ({
+  cmsSources: { PUBLISHER: 'publisher', WAGTAIL: 'wagtail', NPR: 'npr', SIMPLECAST: 'simplecast' },
+  mediaTypeRoutes: {
+    show: '/browse/shows/',
+    story: '/story/',
+  },
+}))
+
+vi.mock('~/composables/data/articlePages', () => ({
+  normalizeArticlePage: vi.fn(async (page: any) => page),
+  normalizePublisherPage: vi.fn((page: any) => page),
+  normalizeWagtailPage: vi.fn((page: any) => page),
+}))
+
+vi.mock('~/utilities/curatedContent', () => ({
+  transformCuratedContent: vi.fn(),
+}))
+
+// @ts-expect-error test-only global
+globalThis.defineEventHandler = (handler: unknown) => handler
+// @ts-expect-error test-only global
+globalThis.getQuery = (event: any) => event?.query || {}
+// @ts-expect-error test-only global
+globalThis.createError = (options: any) => Object.assign(new Error(options.statusMessage), options)
+// @ts-expect-error test-only global
+globalThis.useRuntimeConfig = () => ({
+  public: {
+    AVIARY_BASE_API: 'https://cms.prod.nypr.digital/api/v2/',
+    PUBLISHER_BASE_API: 'https://publisher.test/api/',
+    cmsSite: 'wnyc.org:443',
+  },
+})
+
+describe('CMS route redirects', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    axiosMock.mockReset()
+    axiosGetMock.mockReset()
+  })
+
+  it('returns Aviary redirect metadata for missing Publisher stories under /story', async () => {
+    const redirectLocation = '/story/new-story/'
+
+    axiosMock.mockRejectedValue({ response: { status: 404 } })
+    axiosGetMock.mockImplementation(async (url: string) => {
+      if (url === 'https://cms.prod.nypr.digital/story/old-story') {
+        return {
+          status: 301,
+          headers: {
+            location: redirectLocation,
+          },
+        }
+      }
+
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const handler = (await import('../../server/api/story/[cmsSource]/[storyId]')).default
+    const event: any = {
+      context: { params: { cmsSource: 'publisher', storyId: 'old-story' } },
+    }
+
+    await expect(handler(event)).resolves.toEqual({
+      redirect: true,
+      location: redirectLocation,
+      statusCode: 301,
+    })
+
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      'https://cms.prod.nypr.digital/story/old-story',
+      expect.objectContaining({
+        maxRedirects: 0,
+        headers: expect.objectContaining({
+          'X-CMS-Site': 'wnyc.org:443',
+        }),
+      }),
+    )
+  })
+
+  it('returns Aviary redirect metadata for missing Wagtail show pages under /shows', async () => {
+    const redirectLocation = '/shows/new-show/'
+
+    axiosMock.mockRejectedValue({ response: { status: 404 } })
+    axiosGetMock.mockImplementation(async (url: string) => {
+      if (url === 'https://cms.prod.nypr.digital/browse/shows/old-show') {
+        return { status: 404 }
+      }
+
+      if (url === 'https://cms.prod.nypr.digital/shows/old-show') {
+        return {
+          status: 301,
+          headers: {
+            location: redirectLocation,
+          },
+        }
+      }
+
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const handler = (await import('../../server/api/pages/[cmsSource]/[pageSlug]')).default
+    const event: any = {
+      context: { params: { cmsSource: 'wagtail', pageSlug: 'old-show' } },
+    }
+
+    await expect(handler(event)).resolves.toEqual({
+      redirect: true,
+      location: redirectLocation,
+      statusCode: 301,
+    })
+
+    expect(axiosGetMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cms.prod.nypr.digital/shows/old-show',
+      expect.objectContaining({
+        maxRedirects: 0,
+        headers: expect.objectContaining({
+          'X-CMS-Site': 'wnyc.org:443',
+        }),
+      }),
+    )
+  })
+})

--- a/tests/server/cms-route-redirects.spec.ts
+++ b/tests/server/cms-route-redirects.spec.ts
@@ -92,7 +92,70 @@ describe('CMS route redirects', () => {
     )
   })
 
-  it('returns Aviary redirect metadata for missing Wagtail show pages under /shows', async () => {
+  it('follows normalized CMS slash redirects before returning story redirect metadata', async () => {
+    const finalRedirectLocation = '/story/new-story/'
+
+    axiosMock.mockRejectedValue({ response: { status: 404 } })
+    axiosHeadMock.mockImplementation(async (url: string) => {
+      if (url === 'https://cms.prod.nypr.digital/story/old-story') {
+        return {
+          status: 301,
+          headers: {
+            location: 'https://www.wnyc.org/story/old-story/',
+          },
+        }
+      }
+
+      if (url === 'https://cms.prod.nypr.digital/story/old-story/') {
+        return {
+          status: 301,
+          headers: {
+            location: finalRedirectLocation,
+          },
+        }
+      }
+
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const handler = (await import('../../server/api/story/[cmsSource]/[storyId]')).default
+    const event: any = {
+      context: { params: { cmsSource: 'publisher', storyId: 'old-story' } },
+    }
+
+    await expect(handler(event)).resolves.toEqual({
+      redirect: true,
+      location: finalRedirectLocation,
+      statusCode: 301,
+    })
+
+    expect(axiosHeadMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cms.prod.nypr.digital/story/old-story/',
+      expect.objectContaining({
+        maxRedirects: 0,
+      }),
+    )
+  })
+
+  it('does not probe slug redirects for missing numeric Publisher story IDs', async () => {
+    axiosMock.mockRejectedValue({ response: { status: 404 } })
+
+    const handler = (await import('../../server/api/story/[cmsSource]/[storyId]')).default
+    const event: any = {
+      context: { params: { cmsSource: 'publisher', storyId: '12345' } },
+    }
+
+    await expect(handler(event)).resolves.toBeNull()
+    expect(axiosHeadMock).not.toHaveBeenCalled()
+    expect(axiosMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://publisher.test/api/v3/story-pk/12345/',
+      }),
+    )
+  })
+
+  it('routes Aviary redirect metadata for missing Wagtail show pages under /shows', async () => {
     const redirectLocation = '/shows/new-show/'
 
     axiosMock.mockRejectedValue({ response: { status: 404 } })
@@ -120,7 +183,7 @@ describe('CMS route redirects', () => {
 
     await expect(handler(event)).resolves.toEqual({
       redirect: true,
-      location: redirectLocation,
+      location: '/browse/shows/new-show/',
       statusCode: 301,
     })
 

--- a/tests/server/cms-route-redirects.spec.ts
+++ b/tests/server/cms-route-redirects.spec.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const axiosMock = vi.fn()
-const axiosGetMock = vi.fn()
-axiosMock.get = axiosGetMock
+const axiosHeadMock = vi.fn()
+axiosMock.head = axiosHeadMock
 
 vi.mock('axios', () => ({
   default: axiosMock,
@@ -49,14 +49,14 @@ describe('CMS route redirects', () => {
   beforeEach(() => {
     vi.resetModules()
     axiosMock.mockReset()
-    axiosGetMock.mockReset()
+    axiosHeadMock.mockReset()
   })
 
   it('returns Aviary redirect metadata for missing Publisher stories under /story', async () => {
     const redirectLocation = '/story/new-story/'
 
     axiosMock.mockRejectedValue({ response: { status: 404 } })
-    axiosGetMock.mockImplementation(async (url: string) => {
+    axiosHeadMock.mockImplementation(async (url: string) => {
       if (url === 'https://cms.prod.nypr.digital/story/old-story') {
         return {
           status: 301,
@@ -80,7 +80,7 @@ describe('CMS route redirects', () => {
       statusCode: 301,
     })
 
-    expect(axiosGetMock).toHaveBeenCalledWith(
+    expect(axiosHeadMock).toHaveBeenCalledWith(
       'https://cms.prod.nypr.digital/story/old-story',
       expect.objectContaining({
         maxRedirects: 0,
@@ -95,7 +95,7 @@ describe('CMS route redirects', () => {
     const redirectLocation = '/shows/new-show/'
 
     axiosMock.mockRejectedValue({ response: { status: 404 } })
-    axiosGetMock.mockImplementation(async (url: string) => {
+    axiosHeadMock.mockImplementation(async (url: string) => {
       if (url === 'https://cms.prod.nypr.digital/browse/shows/old-show') {
         return { status: 404 }
       }
@@ -123,7 +123,7 @@ describe('CMS route redirects', () => {
       statusCode: 301,
     })
 
-    expect(axiosGetMock).toHaveBeenNthCalledWith(
+    expect(axiosHeadMock).toHaveBeenNthCalledWith(
       2,
       'https://cms.prod.nypr.digital/shows/old-show',
       expect.objectContaining({

--- a/tests/server/cms-route-redirects.spec.ts
+++ b/tests/server/cms-route-redirects.spec.ts
@@ -85,6 +85,7 @@ describe('CMS route redirects', () => {
       expect.objectContaining({
         maxRedirects: 0,
         headers: expect.objectContaining({
+          'Accept-Encoding': 'identity',
           'X-CMS-Site': 'wnyc.org:443',
         }),
       }),
@@ -129,6 +130,7 @@ describe('CMS route redirects', () => {
       expect.objectContaining({
         maxRedirects: 0,
         headers: expect.objectContaining({
+          'Accept-Encoding': 'identity',
           'X-CMS-Site': 'wnyc.org:443',
         }),
       }),


### PR DESCRIPTION
## Summary
- add a shared Aviary raw-path redirect probe for route-specific CMS handlers
- fall back to CMS redirect metadata for missing `/story/...` and show paths, including legacy `/shows/...`
- make story and show pages honor returned redirect metadata