### PR TITLE
WNYC-878 Fix episode player crash

### DIFF
--- a/components/AudioPlayer.vue
+++ b/components/AudioPlayer.vue
@@ -84,6 +84,16 @@ const getDescription = computed(() => {
     : null
 })
 
+const getEpisodeContextLabel = computed(() => {
+  return (
+    currentEpisode.value?.showTitle ||
+    currentEpisode.value?.station ||
+    currentEpisode.value?.headers?.brand?.title ||
+    currentEpisode.value?.show ||
+    ""
+  )
+})
+
 /*function that updated the global useIsPlayerMinimized */
 const updateUseIsPlayerMinimized = (e) => {
   trackClickEvent(
@@ -480,11 +490,7 @@ onMounted(async () => {
         <template #expanded-player-title>
           <PipeData v-if="!isLiveStream" class="text-xs md:text-base">
             <template #left>
-              {{
-                currentEpisode.showTitle ||
-                currentEpisode.station ||
-                currentEpisode.headers.brand.title
-              }}
+              {{ getEpisodeContextLabel }}
             </template>
             <template #right>
               {{ getDate(currentEpisode) }}

--- a/tests/audio-player.spec.ts
+++ b/tests/audio-player.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('audio player episode context label', () => {
+  it('does not require episode data to include headers', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'components/AudioPlayer.vue'),
+      'utf8'
+    )
+
+    expect(source).toContain('const getEpisodeContextLabel = computed(() => {')
+    expect(source).toContain('currentEpisode.value?.headers?.brand?.title')
+    expect(source).not.toContain('currentEpisode.headers.brand.title')
+  })
+})


### PR DESCRIPTION
Fixes the BL Show episodes listing crash by making the audio player’s episode context label tolerate Simplecast cards that do not include `headers`, with a regression test covering the unsafe access. Verified with `npm test -- --run tests/audio-player.spec.ts`.