### PR TITLE
WNYC-904, event badge fixes

### DIFF
--- a/components/LatestNewsUpdates.vue
+++ b/components/LatestNewsUpdates.vue
@@ -21,6 +21,7 @@ const props = defineProps({
           :newsData="props.localNewscast"
           sourceLabel="WNYC"
           badgeLabel="NEW YORK NEWS"
+          badgeClass="news-card-badge local-news"
           @onClick="togglePlayEpisode(props.localNewscast)"
         />
       </div>
@@ -30,8 +31,7 @@ const props = defineProps({
           :newsData="props.nationalNewscast"
           sourceLabel="NPR"
           badgeLabel="U.S. & WORLD NEWS"
-          bagdeColor="var(--p-surface-0)"
-          badgeBgColor="var(--p-indigo-500)"
+          badgeClass="news-card-badge world-news"
           @onClick="togglePlayEpisode(props.nationalNewscast)"
         />
       </div>

--- a/components/MediaCard.vue
+++ b/components/MediaCard.vue
@@ -751,8 +751,7 @@ const eventData = ref(isEvent ? useEventData(reactiveData) : null)
                   v-for="badge in eventData?.eventTypeBadges"
                   :key="badge.label"
                   :label="badge.label"
-                  :color="badge.color"
-                  :bg-color="badge.bg"
+                  :classNames="badge.classNames"
                 />
               </div>
             </div>
@@ -1047,6 +1046,15 @@ $contentPaddingY: 1.25rem;
     :deep(.event-button .content) {
       color: #101012;
     }
+  }
+}
+</style>
+
+<style lang="scss">
+@include media(">md") {
+  .media-card .badge.event-type-badge .content {
+    color: var(--p-text-color);
+    background-color: var(--p-surface-0);
   }
 }
 </style>

--- a/components/NewsCard.vue
+++ b/components/NewsCard.vue
@@ -14,13 +14,9 @@ const props = defineProps({
     type: String,
     default: "Local News",
   },
-  bagdeColor: {
+  badgeClass: {
     type: String,
-    default: "var(--p-surface-950)",
-  },
-  badgeBgColor: {
-    type: String,
-    default: "var(--p-yellow-500)",
+    default: "news-card",
   },
 })
 
@@ -37,8 +33,7 @@ const emit = defineEmits(["on-click"])
     <div>
       <VBadge
         :label="props.badgeLabel"
-        :color="props.bagdeColor"
-        :bg-color="props.badgeBgColor"
+        :classNames="props.badgeClass"
       />
       <div class="news-title mt-2">
         <h2 class="text-sm md:text-base">{{ props.newsData?.cardTitle }}</h2>

--- a/components/VBadge.vue
+++ b/components/VBadge.vue
@@ -5,19 +5,15 @@ const props = defineProps({
     default: null,
     required: true,
   },
-  bgColor: {
+  classNames: {
     type: String,
-    default: "var(--p-yellow-500)",
-  },
-  color: {
-    type: String,
-    default: "var(--p-surface-950)",
+    default: null,
   },
 })
 </script>
 
 <template>
-  <div class="badge">
+  <div :class="`badge ${props.classNames}`">
     <div class="content">{{ props.label }}</div>
   </div>
 </template>
@@ -31,11 +27,37 @@ const props = defineProps({
     font-size: var(--font-size-2);
     padding: 1px 6px;
     border-radius: 2px;
-    color: v-bind(color);
-    background-color: v-bind(bgColor);
     width: auto;
     font-weight: var(--font-weight-600);
     letter-spacing: 0.5px;
   }
+}
+.badge .content {
+  color: var(--p-surface-950);
+  background-color: var(--p-yellow-500);
+}
+.badge.news-card-badge .content {
+  color: var(--p-surface-950);
+  background-color: var(--p-yellow-500);
+}
+.badge.news-card-badge.local-news .content {
+  color: var(--p-surface-950);
+  background-color: var(--p-yellow-500);
+}
+.badge.news-card-badge.world-news .content {
+  color: var(--p-surface-0);
+  background-color: var(--p-indigo-500);
+}
+.badge.event-location-badge.in-person .content {
+  color: var(--p-surface-0);
+  background-color: var(--electric-violet);
+}
+.badge.event-location-badge.live-stream .content {
+  color: var(--p-text-color);
+  background-color: var(--sea-green);
+}
+.badge.event-type-badge .content {
+  color: var(--p-text-color);
+  background-color: var(--p-surface-25);
 }
 </style>

--- a/composables/useEventData.ts
+++ b/composables/useEventData.ts
@@ -2,10 +2,35 @@ import { computed, unref } from "vue"
 import type { ComputedRef, Ref } from "vue"
 import { formatTime } from "~/utilities/helpers"
 
+
+const WNYC_EVENTS_TAGS_NEEDLES = ["wnyc_events", "wnyc-events", "wnyc events"]
+const WQXR_EVENTS_TAGS_NEEDLES = ["wqxr_events", "wqxr-events", "wqxr events"]
+const PARTNER_EVENTS_TAGS_NEEDLES = ["partner_events", "partner-events", "partner events"]
+const COMMUNITY_EVENTS_TAGS_NEEDLES = ["community_events", "community-events", "community events"]
 const LIVE_STREAM_TAG_NEEDLES = ["live_stream", "live-stream", "livestream"]
 const IN_PERSON_TAG_NEEDLES = ["in_person", "in-person", "in_studio"]
 
 export const EVENT_BADGE_STYLES = {
+  wnycEvents: {
+    label: "WNYC EVENTS",
+    color: "var(--p-text-color)",
+    bg: "var(--p-surface-25",
+  },
+  wqxrEvents: {
+    label: "WQXR EVENTS",
+    color: "var(--p-text-color)",
+    bg: "var(--p-surface-25)",
+  },
+  partnerEvents: {
+    label: "PARTNER EVENTS",
+    color: "var(--p-text-color)",
+    bg: "var(--p-surface-25)",
+  },
+  communityEvents: {
+    label: "COMMUNITY EVENTS",
+    color: "var(--p-text-color)",
+    bg: "var(--p-surface-25)",
+  },
   liveStream: {
     label: "LIVE STREAM",
     color: "var(--p-text-color)",
@@ -87,6 +112,18 @@ export const useEventData = (eventSource: EventLikeRef) => {
     () => venueName.value || eventLocation.value || null
   )
 
+  const hasWnycEvents = computed(() =>
+    matchesTag(tags.value, WNYC_EVENTS_TAGS_NEEDLES)
+  )
+  const hasWqxrEvents = computed(() =>
+    matchesTag(tags.value, WQXR_EVENTS_TAGS_NEEDLES)
+  )
+  const hasPartnerEvents = computed(() =>
+    matchesTag(tags.value, PARTNER_EVENTS_TAGS_NEEDLES)
+  )
+  const hasCommunityEvents = computed(() =>
+    matchesTag(tags.value, COMMUNITY_EVENTS_TAGS_NEEDLES)
+  )
   const hasLiveStream = computed(() =>
     matchesTag(tags.value, LIVE_STREAM_TAG_NEEDLES)
   )
@@ -95,6 +132,10 @@ export const useEventData = (eventSource: EventLikeRef) => {
   )
 
   const eventTypeBadges = computed(() => [
+    ...(hasWnycEvents.value ? [EVENT_BADGE_STYLES.wnycEvents] : []),
+    ...(hasWqxrEvents.value ? [EVENT_BADGE_STYLES.wqxrEvents] : []),
+    ...(hasPartnerEvents.value ? [EVENT_BADGE_STYLES.partnerEvents] : []),
+    ...(hasCommunityEvents.value ? [EVENT_BADGE_STYLES.communityEvents] : []),
     ...(hasInPerson.value ? [EVENT_BADGE_STYLES.inPerson] : []),
     ...(hasLiveStream.value ? [EVENT_BADGE_STYLES.liveStream] : []),
   ])
@@ -114,6 +155,10 @@ export const useEventData = (eventSource: EventLikeRef) => {
     locationName,
     hasLiveStream,
     hasInPerson,
+    hasWnycEvents,
+    hasWqxrEvents,
+    hasPartnerEvents,
+    hasCommunityEvents,
     eventTypeBadges,
     eventCtaUrl,
   }

--- a/composables/useEventData.ts
+++ b/composables/useEventData.ts
@@ -13,33 +13,27 @@ const IN_PERSON_TAG_NEEDLES = ["in_person", "in-person", "in_studio"]
 export const EVENT_BADGE_STYLES = {
   wnycEvents: {
     label: "WNYC EVENTS",
-    color: "var(--p-text-color)",
-    bg: "var(--p-surface-25",
+    classNames: "event-type-badge wnyc-events",
   },
   wqxrEvents: {
     label: "WQXR EVENTS",
-    color: "var(--p-text-color)",
-    bg: "var(--p-surface-25)",
+    classNames: "event-type-badge wqxr-events",
   },
   partnerEvents: {
     label: "PARTNER EVENTS",
-    color: "var(--p-text-color)",
-    bg: "var(--p-surface-25)",
+    classNames: "event-type-badge partner-events",
   },
   communityEvents: {
     label: "COMMUNITY EVENTS",
-    color: "var(--p-text-color)",
-    bg: "var(--p-surface-25)",
+    classNames: "event-type-badge community-events",
   },
   liveStream: {
     label: "LIVE STREAM",
-    color: "var(--p-text-color)",
-    bg: "var(--sea-green)",
+    classNames: "event-location-badge live-stream",
   },
   inPerson: {
     label: "IN-PERSON",
-    color: "var(--p-surface-0)",
-    bg: "var(--electric-violet)",
+    classNames: "event-location-badge in-person",
   },
 } as const
 

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -2,12 +2,11 @@
 import { useToast } from "primevue/usetoast"
 import { useTopStories } from "~/composables/useTopStories"
 import { EVENT_BADGE_STYLES, useEventData } from "~/composables/useEventData"
-import { dynamicNavigation } from "~/utilities/helpers"
 import { getEventTitle, getEventDescription, getEventImage } from "~/utilities/metadataHelpers"
 import useSeoMetaOverrides from "~/composables/useSeoMetaOverrides"
 import useSocialMetaOverrides from "~/composables/useSocialMetaOverrides"
 
-const { getFilteredTopStories,topStories } = useTopStories()
+const { getFilteredTopStories } = useTopStories()
 const config = useRuntimeConfig()
 const route = useRoute()
 const toast = useToast()
@@ -122,7 +121,7 @@ useHead({
 })
 useSeoMeta({
   title: pageTitle,
-  description: description,
+  description,
   ogTitle: pageTitle,
   ogDescription: description,
 })

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -64,12 +64,19 @@ const {
   locationName,
   hasLiveStream,
   hasInPerson,
+  hasWnycEvents,
+  hasWqxrEvents,
+  hasPartnerEvents,
+  hasCommunityEvents,
   eventCtaUrl,
 } = useEventData(eventData)
 
 const eventTimeLabel = computed(() => timeLabel.value?.toLowerCase() ?? null)
 const eventBadges = computed(() => [
-  { label: "WNYC EVENTS", color: "var(--p-text-color)", bg: "var(--p-surface-200)" },
+  ...(hasWnycEvents.value ? [EVENT_BADGE_STYLES.wnycEvents] : []),
+  ...(hasWqxrEvents.value ? [EVENT_BADGE_STYLES.wqxrEvents] : []),
+  ...(hasPartnerEvents.value ? [EVENT_BADGE_STYLES.partnerEvents] : []),
+  ...(hasCommunityEvents.value ? [EVENT_BADGE_STYLES.communityEvents] : []),
   ...(hasInPerson.value ? [EVENT_BADGE_STYLES.inPerson] : []),
   ...(hasLiveStream.value ? [EVENT_BADGE_STYLES.liveStream] : []),
 ])

--- a/pages/events/[slug].vue
+++ b/pages/events/[slug].vue
@@ -174,8 +174,7 @@ useSocialMetaOverrides(eventData)
                         v-for="badge in eventBadges"
                         :key="badge.label"
                         :label="badge.label"
-                        :color="badge.color"
-                        :bg-color="badge.bg"
+                        :classNames="badge.classNames"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/WNYC-904

- Add support for event type badges (wnyc_events, wqxr_events, partner_events, community_events)
- Removed hardcoded wnyc_events tag on event page headers
- Refactored badge colors to use CSS so the bdg color can respond to context and breakpoints
- Event type badges are light gray (#f5f5f5), except when on event cards, above the `md` breakpoint, where they are white (#ffffff) instead, (so we don't have gray on gray)